### PR TITLE
Feat: Add callbacks for all onAccept scenarios #CCM-24

### DIFF
--- a/src/LmcCookieConsentManager.js
+++ b/src/LmcCookieConsentManager.js
@@ -18,16 +18,16 @@ const defaultOptions = {
 };
 
 /**
- * @param {Object} args - Options for cookie consent manager
- * @param {string} args.currentLang - Specify one of the languages you have defined
- * @param {string} args.themeCss - Specify file to the .css file
- * @param {function} args.onFirstAccept - Callback to be executed right after any consent is just accepted
- * @param {function} args.onFirstAcceptOnlyNecessary - Callback to be executed right after only necessary cookies are accepted
- * @param {function} args.onFirstAcceptAll - Callback to be executed right after all cookies are accepted
- * @param {function} args.onAccept - Callback to be executed when any consent is detected (either given right now or already saved previously)
- * @param {function} args.onAcceptOnlyNecessary - Callback to be executed when consent with only necessary cookies is detected (either given right now or already saved previously)
- * @param {function} args.onAcceptAll - Callback to be executed when consent with all cookies is detected (either given right now or already saved previously)
- * @param {Object} args.config - Override default config. See https://github.com/orestbida/cookieconsent/blob/master/Readme.md#all-available-options
+ * @param {Object} [args] - Options for cookie consent manager
+ * @param {string} [args.currentLang] - Specify one of the languages you have defined
+ * @param {string} [args.themeCss] - Specify file to the .css file
+ * @param {function} [args.onFirstAccept] - Callback to be executed right after any consent is just accepted
+ * @param {function} [args.onFirstAcceptOnlyNecessary] - Callback to be executed right after only necessary cookies are accepted
+ * @param {function} [args.onFirstAcceptAll] - Callback to be executed right after all cookies are accepted
+ * @param {function} [args.onAccept] - Callback to be executed when any consent is detected (either given right now or already saved previously)
+ * @param {function} [args.onAcceptOnlyNecessary] - Callback to be executed when consent with only necessary cookies is detected (either given right now or already saved previously)
+ * @param {function} [args.onAcceptAll] - Callback to be executed when consent with all cookies is detected (either given right now or already saved previously)
+ * @param {Object} [args.config] - Override default config. See https://github.com/orestbida/cookieconsent/blob/master/Readme.md#all-available-options
  */
 const LmcCookieConsentManager = (args) => {
   const options = { ...defaultOptions, ...args };

--- a/src/LmcCookieConsentManager.js
+++ b/src/LmcCookieConsentManager.js
@@ -44,10 +44,10 @@ const LmcCookieConsentManager = (args) => {
   } = options;
   const cookieName = 'lmc_ccm';
 
-  const cookieconsent = window.initCookieConsent();
-  const isFirstTimeAccept = !cookieconsent.validCookie(cookieName);
+  const cookieConsent = window.initCookieConsent();
+  const isFirstTimeAccept = !cookieConsent.validCookie(cookieName);
 
-  cookieconsent.run({
+  cookieConsent.run({
     current_lang: currentLang,
     auto_language: true,
     theme_css: themeCss,
@@ -66,7 +66,7 @@ const LmcCookieConsentManager = (args) => {
       },
     },
     onAccept: (cookie) => {
-      const givenLevels = cookieconsent.get('level');
+      const givenLevels = cookieConsent.get('level');
       const acceptedOnlyNecessary =
         givenLevels.length === 1 && givenLevels[0] === 'necessary';
 

--- a/src/LmcCookieConsentManager.js
+++ b/src/LmcCookieConsentManager.js
@@ -8,7 +8,12 @@ import { config as configSk } from './languages/sk';
 const defaultOptions = {
   currentLang: 'cs',
   themeCss: '',
+  onFirstAccept: (cookie) => {},
+  onFirstAcceptOnlyNecessary: (cookie) => {},
+  onFirstAcceptAll: (cookie) => {},
   onAccept: (cookie) => {},
+  onAcceptOnlyNecessary: (cookie) => {},
+  onAcceptAll: (cookie) => {},
   config: {},
 };
 
@@ -16,20 +21,37 @@ const defaultOptions = {
  * @param {Object} args - Options for cookie consent manager
  * @param {string} args.currentLang - Specify one of the languages you have defined
  * @param {string} args.themeCss - Specify file to the .css file
- * @param {function} args.onAccept - Callback to be executed after any consent is detected (either given now or already saved previously)
+ * @param {function} args.onFirstAccept - Callback to be executed right after any consent is just accepted
+ * @param {function} args.onFirstAcceptOnlyNecessary - Callback to be executed right after only necessary cookies are accepted
+ * @param {function} args.onFirstAcceptAll - Callback to be executed right after all cookies are accepted
+ * @param {function} args.onAccept - Callback to be executed when any consent is detected (either given right now or already saved previously)
+ * @param {function} args.onAcceptOnlyNecessary - Callback to be executed when consent with only necessary cookies is detected (either given right now or already saved previously)
+ * @param {function} args.onAcceptAll - Callback to be executed when consent with all cookies is detected (either given right now or already saved previously)
  * @param {Object} args.config - Override default config. See https://github.com/orestbida/cookieconsent/blob/master/Readme.md#all-available-options
  */
 const LmcCookieConsentManager = (args) => {
   const options = { ...defaultOptions, ...args };
-  const { currentLang, themeCss, onAccept, config } = options;
+  const {
+    currentLang,
+    themeCss,
+    onFirstAccept,
+    onFirstAcceptOnlyNecessary,
+    onFirstAcceptAll,
+    onAccept,
+    onAcceptOnlyNecessary,
+    onAcceptAll,
+    config,
+  } = options;
+  const cookieName = 'lmc_ccm';
 
   const cookieconsent = window.initCookieConsent();
+  const isFirstTimeAccept = !cookieconsent.validCookie(cookieName);
 
   cookieconsent.run({
     current_lang: currentLang,
     auto_language: true,
     theme_css: themeCss,
-    cookie_name: 'lmc_ccm',
+    cookie_name: cookieName,
     cookie_expiration: 365,
     use_rfc_cookie: true,
     autorun: true,
@@ -44,6 +66,10 @@ const LmcCookieConsentManager = (args) => {
       },
     },
     onAccept: (cookie) => {
+      const givenLevels = cookieconsent.get('level');
+      const acceptedOnlyNecessary =
+        givenLevels.length === 1 && givenLevels[0] === 'necessary';
+
       window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({
         event: 'CookieConsent-update',
@@ -56,6 +82,15 @@ const LmcCookieConsentManager = (args) => {
       });
 
       onAccept(cookie);
+
+      if (isFirstTimeAccept) {
+        onFirstAccept(cookie);
+        acceptedOnlyNecessary
+          ? onFirstAcceptOnlyNecessary(cookie)
+          : onFirstAcceptAll(cookie);
+      }
+
+      acceptedOnlyNecessary ? onAcceptOnlyNecessary(cookie) : onAcceptAll(cookie);
     },
     languages: {
       cs: configCs,

--- a/src/LmcCookieConsentManager.js
+++ b/src/LmcCookieConsentManager.js
@@ -8,12 +8,12 @@ import { config as configSk } from './languages/sk';
 const defaultOptions = {
   currentLang: 'cs',
   themeCss: '',
-  onFirstAccept: (cookie) => {},
-  onFirstAcceptOnlyNecessary: (cookie) => {},
-  onFirstAcceptAll: (cookie) => {},
-  onAccept: (cookie) => {},
-  onAcceptOnlyNecessary: (cookie) => {},
-  onAcceptAll: (cookie) => {},
+  onFirstAccept: (cookie, cookieConsent) => {},
+  onFirstAcceptOnlyNecessary: (cookie, cookieConsent) => {},
+  onFirstAcceptAll: (cookie, cookieConsent) => {},
+  onAccept: (cookie, cookieConsent) => {},
+  onAcceptOnlyNecessary: (cookie, cookieConsent) => {},
+  onAcceptAll: (cookie, cookieConsent) => {},
   config: {},
 };
 
@@ -81,16 +81,18 @@ const LmcCookieConsentManager = (args) => {
         'CookieConsent.revision': cookie.revision,
       });
 
-      onAccept(cookie);
+      onAccept(cookie, cookieConsent);
 
       if (isFirstTimeAccept) {
-        onFirstAccept(cookie);
+        onFirstAccept(cookie, cookieConsent);
         acceptedOnlyNecessary
-          ? onFirstAcceptOnlyNecessary(cookie)
-          : onFirstAcceptAll(cookie);
+          ? onFirstAcceptOnlyNecessary(cookie, cookieConsent)
+          : onFirstAcceptAll(cookie, cookieConsent);
       }
 
-      acceptedOnlyNecessary ? onAcceptOnlyNecessary(cookie) : onAcceptAll(cookie);
+      acceptedOnlyNecessary
+        ? onAcceptOnlyNecessary(cookie, cookieConsent)
+        : onAcceptAll(cookie, cookieConsent);
     },
     languages: {
       cs: configCs,


### PR DESCRIPTION
There are six scenarios for the callback:

1. `onAccept()` - when any consent is detected (either given right now or already saved previously). This is the same behavior as the native `onAccept()` callback of the library. This one we already have from #17 .
2. `onAcceptOnlyNecessary()` (aka "Reject") - when consent with only necessary cookies is detected (either given right now or already saved previously) .
3. `onAcceptAll()` - when consent with all cookies is detected (either given right now or already saved previously)
4. `onFirstAccept()` - right after any consent is just accepted by the user.
5. `onFirstAcceptOnlyNecessary()` (aka "Reject") - right after only necessary cookies are accepted by the user. May be useful for metrics and removing current cookies.
6. `onFirstAcceptAll()` - right after all cookies are accepted by the user. May be useful eg. for sending metrics.
 
I'm considering whether we need to provide all of them. I can imagine usecase for almost each of them, though I'm not sure whether someone will actually need it. However it makes sense to me to have all of them for consistency.

What do you think?