### PR TITLE
Feat: Return CookieConsent instance from the init function

### DIFF
--- a/src/LmcCookieConsentManager.js
+++ b/src/LmcCookieConsentManager.js
@@ -28,6 +28,7 @@ const defaultOptions = {
  * @param {function} [args.onAcceptOnlyNecessary] - Callback to be executed when consent with only necessary cookies is detected (either given right now or already saved previously)
  * @param {function} [args.onAcceptAll] - Callback to be executed when consent with all cookies is detected (either given right now or already saved previously)
  * @param {Object} [args.config] - Override default config. See https://github.com/orestbida/cookieconsent/blob/master/Readme.md#all-available-options
+ * @returns {Object} Instance of the underlying CookieConsent component. For available API, see https://github.com/orestbida/cookieconsent#apis--configuration-parameters
  */
 const LmcCookieConsentManager = (args) => {
   const options = { ...defaultOptions, ...args };
@@ -103,6 +104,8 @@ const LmcCookieConsentManager = (args) => {
     // override default config if necessary
     ...config,
   });
+
+  return cookieConsent;
 };
 
 export default LmcCookieConsentManager;


### PR DESCRIPTION
Instance of the underlying cookie consent library is now returned also from the our constructor.

This may be useful for some edge-cases when you need to access the component in a different workflow then in callback.

```html
<script>
  window.addEventListener('load', function () {
    window.cc = initLmcCookieConsentManager();
  });
</script>

<a href="..." onclick="cc.allowedCategory('analytics') ? console.log('log analytics') : console.log('do not log');">Tracked link</a>

```