### PR TITLE
Feat: Enable management of third-party scripts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,19 @@ set `type` to `type="text/plain"` and add `data-cookiecategory` attribute with r
 
 See [full documentation](https://github.com/orestbida/cookieconsent#manage-third-party-scripts) for this feature.
 
+This feature is enabled by default. If you'd like to disable it, you can do so by overriding `page_scripts` value in
+`config` option:
+
+```js
+initLmcCookieConsentManager(
+  {
+    'config': {
+      'page_scripts': false
+    }
+  }
+);
+```
+
 ## Configuration
 
 Optional config parameters could be provided on plugin initialization in the configuration object.
@@ -131,6 +144,9 @@ initLmcCookieConsentManager(
     'autodetectLang': false,
     'onAcceptAll': (cookie, cookieConsent) => {
       // custom code
+    },
+    'config': {
+      // overrides of default config, see https://github.com/orestbida/cookieconsent#all-available-options
     },
   }
 );

--- a/src/LmcCookieConsentManager.js
+++ b/src/LmcCookieConsentManager.js
@@ -51,16 +51,16 @@ const LmcCookieConsentManager = (args) => {
   const isFirstTimeAccept = !cookieConsent.validCookie(cookieName);
 
   cookieConsent.run({
-    current_lang: defaultLang,
-    auto_language: autodetectLang,
-    theme_css: themeCss,
-    cookie_name: cookieName,
-    cookie_expiration: 365,
-    use_rfc_cookie: true,
-    autorun: true,
-    delay: 0,
-    force_consent: false,
+    auto_language: autodetectLang, // Enable detection from navigator.language
+    autorun: true, // Show the cookie consent banner as soon as possible
+    cookie_expiration: 365, // 1 year
+    cookie_name: cookieName, // Predefined cookie name. Do not override.
+    current_lang: defaultLang, // Default language used when auto_language is false (or when autodetect failed)
+    delay: 0, // Show the modal immediately after init
+    force_consent: false, // Do not force the consent before page could be used
     hide_from_bots: true, // To be hidden also from Selenium
+    theme_css: themeCss, // Path to external CSS loaded by the component. Empty to disable.
+    use_rfc_cookie: true, // Store cookie content in RFC compatible format.
     gui_options: {
       consent_modal: {
         layout: 'bar', // box/cloud/bar

--- a/src/LmcCookieConsentManager.js
+++ b/src/LmcCookieConsentManager.js
@@ -59,6 +59,7 @@ const LmcCookieConsentManager = (args) => {
     delay: 0, // Show the modal immediately after init
     force_consent: false, // Do not force the consent before page could be used
     hide_from_bots: true, // To be hidden also from Selenium
+    page_scripts: true, // Manage third-party scripts loaded using <script>
     theme_css: themeCss, // Path to external CSS loaded by the component. Empty to disable.
     use_rfc_cookie: true, // Store cookie content in RFC compatible format.
     gui_options: {


### PR DESCRIPTION
This adds default configuration to enable third-party script management:
```js
page_scripts: true, // Manage third-party scripts loaded using <script>
```

If someone won't use this feature, the overhead in the vanilla library is one call of `var scripts = document.querySelectorAll('script[' + _config.script_selector + ']');` on init. I guess this is acceptable performance tradeoff?

Other option would be leave this as default and add this the configurable parameters. What do you think?