### PR TITLE
Configurable language autodetection

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Optional config parameters could be provided on plugin initialization in the con
 ```js
 initLmcCookieConsentManager(
   {
-    'currentLang': 'cs',
+    'defaultLang': 'cs',
     'onAcceptAll': (cookie, cookieConsent) => {
       // custom code
     },
@@ -135,7 +135,8 @@ initLmcCookieConsentManager(
 
 | Option        | Type     | Default value                  | Description                                                                                                                               |
 |---------------|----------|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| `currentLang` | string   | 'cs'                           | Default language. One of `cs`, `en`, `sk`, `pl`. This language will be used when autodetect is disabled or when it fails.                 |
+| `defaultLang` | string   | 'cs'                           | Default language. One of `cs`, `en`, `sk`, `pl`. This language will be used when autodetect is disabled or when it fails.                 |
+| `autodetectLang`| string | true                           | Autodetect language from the browser. If autodetect fails or detects not supported language, fallback to `defaultLang`.<br>When disabled, force language to `defaultLang`. |
 | `themeCss`    | string   | ''                             | Specify path to the .css file                                                                                                             |
 | `config`      | Object   | {}                             | Override default config of the underlying library. For all parameters see [original library](https://github.com/orestbida/cookieconsent#all-available-options). |
 | `on*` callbacks| function | (cookie, cookieConsent) => {} | See below for configurable callbacks. |

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Optional config parameters could be provided on plugin initialization in the con
 initLmcCookieConsentManager(
   {
     'defaultLang': 'cs',
+    'autodetectLang': false,
     'onAcceptAll': (cookie, cookieConsent) => {
       // custom code
     },
@@ -136,7 +137,7 @@ initLmcCookieConsentManager(
 | Option        | Type     | Default value                  | Description                                                                                                                               |
 |---------------|----------|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
 | `defaultLang` | string   | 'cs'                           | Default language. One of `cs`, `en`, `sk`, `pl`. This language will be used when autodetect is disabled or when it fails.                 |
-| `autodetectLang`| string | true                           | Autodetect language from the browser. If autodetect fails or detects not supported language, fallback to `defaultLang`.<br>When disabled, force language to `defaultLang`. |
+| `autodetectLang`| string | true                           | Autodetect language from the browser. If autodetect fails or if unsupported language is detected, fallback to `defaultLang`.<br>When disabled, force language to `defaultLang`. |
 | `themeCss`    | string   | ''                             | Specify path to the .css file                                                                                                             |
 | `config`      | Object   | {}                             | Override default config of the underlying library. For all parameters see [original library](https://github.com/orestbida/cookieconsent#all-available-options). |
 | `on*` callbacks| function | (cookie, cookieConsent) => {} | See below for configurable callbacks. |

--- a/examples/index.html
+++ b/examples/index.html
@@ -17,7 +17,7 @@
   window.addEventListener('load', function () {
     initLmcCookieConsentManager(
       {
-        'currentLang': 'cs',
+        'defaultLang': 'cs',
         'onAcceptAll': (cookie, cookieConsent) => {
           console.log(cookie);
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -17,7 +17,8 @@
   window.addEventListener('load', function () {
     initLmcCookieConsentManager(
       {
-        'defaultLang': 'cs',
+        'defaultLang': 'en',
+        'autodetectLang': false,
         'onAcceptAll': (cookie, cookieConsent) => {
           console.log(cookie);
 

--- a/src/LmcCookieConsentManager.js
+++ b/src/LmcCookieConsentManager.js
@@ -7,6 +7,7 @@ import { config as configSk } from './languages/sk';
 
 const defaultOptions = {
   defaultLang: 'cs',
+  autodetectLang: true,
   themeCss: '',
   onFirstAccept: (cookie, cookieConsent) => {},
   onFirstAcceptOnlyNecessary: (cookie, cookieConsent) => {},
@@ -20,6 +21,7 @@ const defaultOptions = {
 /**
  * @param {Object} [args] - Options for cookie consent manager
  * @param {string} [args.defaultLang] - Default language. Must be one of predefined languages.
+ * @param {boolean} [args.autodetectLang] - Autodetect language from the browser
  * @param {string} [args.themeCss] - Specify file to the .css file
  * @param {function} [args.onFirstAccept] - Callback to be executed right after any consent is just accepted
  * @param {function} [args.onFirstAcceptOnlyNecessary] - Callback to be executed right after only necessary cookies are accepted
@@ -34,6 +36,7 @@ const LmcCookieConsentManager = (args) => {
   const options = { ...defaultOptions, ...args };
   const {
     defaultLang,
+    autodetectLang,
     themeCss,
     onFirstAccept,
     onFirstAcceptOnlyNecessary,
@@ -49,7 +52,7 @@ const LmcCookieConsentManager = (args) => {
 
   cookieConsent.run({
     current_lang: defaultLang,
-    auto_language: true,
+    auto_language: autodetectLang,
     theme_css: themeCss,
     cookie_name: cookieName,
     cookie_expiration: 365,

--- a/src/LmcCookieConsentManager.js
+++ b/src/LmcCookieConsentManager.js
@@ -6,7 +6,7 @@ import { config as configPl } from './languages/pl';
 import { config as configSk } from './languages/sk';
 
 const defaultOptions = {
-  currentLang: 'cs',
+  defaultLang: 'cs',
   themeCss: '',
   onFirstAccept: (cookie, cookieConsent) => {},
   onFirstAcceptOnlyNecessary: (cookie, cookieConsent) => {},
@@ -19,7 +19,7 @@ const defaultOptions = {
 
 /**
  * @param {Object} [args] - Options for cookie consent manager
- * @param {string} [args.currentLang] - Specify one of the languages you have defined
+ * @param {string} [args.defaultLang] - Default language. Must be one of predefined languages.
  * @param {string} [args.themeCss] - Specify file to the .css file
  * @param {function} [args.onFirstAccept] - Callback to be executed right after any consent is just accepted
  * @param {function} [args.onFirstAcceptOnlyNecessary] - Callback to be executed right after only necessary cookies are accepted
@@ -33,7 +33,7 @@ const defaultOptions = {
 const LmcCookieConsentManager = (args) => {
   const options = { ...defaultOptions, ...args };
   const {
-    currentLang,
+    defaultLang,
     themeCss,
     onFirstAccept,
     onFirstAcceptOnlyNecessary,
@@ -44,12 +44,11 @@ const LmcCookieConsentManager = (args) => {
     config,
   } = options;
   const cookieName = 'lmc_ccm';
-
   const cookieConsent = window.initCookieConsent();
   const isFirstTimeAccept = !cookieConsent.validCookie(cookieName);
 
   cookieConsent.run({
-    current_lang: currentLang,
+    current_lang: defaultLang,
     auto_language: true,
     theme_css: themeCss,
     cookie_name: cookieName,


### PR DESCRIPTION
From talks with some engineers it seems the autodetection will be often disabled (they will just force the language based on current language version of the site). (Sidenote - maybe we should consider whether the autodetection should not be disabled by default...)

Furthermore, I renamed `currentLang` to `defaultLang`, which in my opinion better describes what the value actually means from configuration perspective.