### PR TITLE
Chore: Add repository URL to make it shown also on npmjs.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
   "name": "@lmc-eu/cookie-consent-manager",
   "version": "0.1.0",
-  "description": "Cookie consent banner compatible with Spirit Design System",
+  "description": "LMC Cookie Consent Manager",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
   },
   "main": "LmcCookieConsentManager.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lmc-eu/cookie-consent-manager.git"
+  },
   "scripts": {
     "prebuild": "rm -rf dist && mkdir -p dist && cp package.json README.md dist/",
     "build:css": "yarn css",


### PR DESCRIPTION
There is now no link to the github repo in the sidebar: https://www.npmjs.com/package/@lmc-eu/cookie-consent-manager