### PR TITLE
Chore/husky on ci

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,6 +20,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Disable husky commit hooks
+        run: npm set-script prepare ""
+
       - name: Build
         run: yarn build
 

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,3 @@
+[ -n "$CI" ] && exit 0
+
 yarn commitlint --edit $1


### PR DESCRIPTION
Disabling husky on CI

see: https://typicode.github.io/husky/#/?id=disable-husky-in-cidocker

Fixing failed build: https://github.com/lmc-eu/cookie-consent-manager/runs/4079677810?check_suite_focus=true