### PR TITLE
Chore: Remove prepare script before publishing package

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,7 +21,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Disable husky commit hooks
-        run: npm set-script prepare ""
+        run: yarn remove-prepare
 
       - name: Build
         run: yarn build

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "version": "yarn changelog && yarn replace-version && git status && git add CHANGELOG.md README.md package.json ./dist && git status",
     "postversion": "echo 'Check and push: `git push --set-upstream origin main && git push --tags`'",
     "release": "yarn version --`./bin/ci/semver.sh`",
-    "replace-version": "node scripts/readme-replace-version.js"
+    "replace-version": "node scripts/readme-replace-version.js",
+    "remove-prepare": "node scripts/remove-prepare.js"
   },
   "dependencies": {
     "@lmc-eu/spirit-design-tokens": "^0.4.0",

--- a/scripts/remove-prepare.js
+++ b/scripts/remove-prepare.js
@@ -1,0 +1,10 @@
+fs = require('fs');
+const packageJson = require('../package.json');
+
+delete packageJson.scripts.prepare;
+
+fs.writeFile('package.json', JSON.stringify(packageJson, null, 2), (error) => {
+  if (error) {
+    return console.log(err);
+  }
+});


### PR DESCRIPTION
  * `set-script` works from npm v7 and we are on node v14 and npm v6
  * we are removing prepare script with husky install because it is
    a lifecycle script that is runned before publish
  * we are publishing from ./dist directory where are no deps installed