### PR TITLE
Remove themeCss config property  #CCM-28

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,6 @@ initLmcCookieConsentManager( // when loaded as a module, these options are passe
 |---------------|----------|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
 | `defaultLang` | string   | 'cs'                           | Default language. One of `cs`, `en`, `sk`, `pl`. This language will be used when autodetect is disabled or when it fails.                 |
 | `autodetectLang`| string | true                           | Autodetect language from the browser. If autodetect fails or if unsupported language is detected, fallback to `defaultLang`.<br>When disabled, force language to `defaultLang`. |
-| `themeCss`    | string   | ''                             | Specify path to the .css file                                                                                                             |
 | `config`      | Object   | {}                             | Override default config of the underlying library. For all parameters see [original library](https://github.com/orestbida/cookieconsent#all-available-options). |
 | `on*` callbacks| function | (cookie, cookieConsent) => {} | See below for configurable callbacks. |
 

--- a/src/LmcCookieConsentManager.js
+++ b/src/LmcCookieConsentManager.js
@@ -8,7 +8,6 @@ import { config as configSk } from './languages/sk';
 const defaultOptions = {
   defaultLang: 'cs',
   autodetectLang: true,
-  themeCss: '',
   onFirstAccept: (cookie, cookieConsent) => {},
   onFirstAcceptOnlyNecessary: (cookie, cookieConsent) => {},
   onFirstAcceptAll: (cookie, cookieConsent) => {},
@@ -22,7 +21,6 @@ const defaultOptions = {
  * @param {Object} [args] - Options for cookie consent manager
  * @param {string} [args.defaultLang] - Default language. Must be one of predefined languages.
  * @param {boolean} [args.autodetectLang] - Autodetect language from the browser
- * @param {string} [args.themeCss] - Specify file to the .css file
  * @param {function} [args.onFirstAccept] - Callback to be executed right after any consent is just accepted
  * @param {function} [args.onFirstAcceptOnlyNecessary] - Callback to be executed right after only necessary cookies are accepted
  * @param {function} [args.onFirstAcceptAll] - Callback to be executed right after all cookies are accepted
@@ -37,7 +35,6 @@ const LmcCookieConsentManager = (args) => {
   const {
     defaultLang,
     autodetectLang,
-    themeCss,
     onFirstAccept,
     onFirstAcceptOnlyNecessary,
     onFirstAcceptAll,
@@ -60,7 +57,6 @@ const LmcCookieConsentManager = (args) => {
     force_consent: false, // Do not force the consent before page could be used
     hide_from_bots: true, // To be hidden also from Selenium
     page_scripts: true, // Manage third-party scripts loaded using <script>
-    theme_css: themeCss, // Path to external CSS loaded by the component. Empty to disable.
     use_rfc_cookie: true, // Store cookie content in RFC compatible format.
     gui_options: {
       consent_modal: {


### PR DESCRIPTION
As discussed, this removes `themeCss` property from the exposed configuration.

We only document the standard way of loading CSS using `<link>` attribute or including it in custom built styles.
