### PR TITLE
Docs: Do not use patch part in URL to update to bugfix versions automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Load default CSS in your `<head>`:
 
 ```html
 <link rel="preconnect" href="https://cdn.jsdelivr.net">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@lmc-eu/cookie-consent-manager@0.5.0/LmcCookieConsentManager.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@lmc-eu/cookie-consent-manager@0.5/LmcCookieConsentManager.min.css">
 ```
 
 Load the script and initialize the plugin right before ending `</body>` tag:
 
 ```html
-<script defer src="https://cdn.jsdelivr.net/npm/@lmc-eu/cookie-consent-manager@0.5.0/init.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/@lmc-eu/cookie-consent-manager@0.5/init.js"></script>
 <script>
 window.addEventListener('load', function () {
   initLmcCookieConsentManager();
@@ -53,8 +53,9 @@ as shown above or to explicitly specify the desired font yourself (head to [Them
 You can load the plugin from a CDN, as in the basic example above.
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@lmc-eu/cookie-consent-manager@0.5.0/LmcCookieConsentManager.min.css">
-<script defer src="https://cdn.jsdelivr.net/npm/@lmc-eu/cookie-consent-manager@0.5.0/init.js"></script>
+<!-- Note we use version "cookie-consent-manager@0.5", which points the latest version of this series (including bugfix releases) -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@lmc-eu/cookie-consent-manager@0.5/LmcCookieConsentManager.min.css">
+<script defer src="https://cdn.jsdelivr.net/npm/@lmc-eu/cookie-consent-manager@0.5/init.js"></script>
 ```
 
 Alternatively, you can also download the latest version from the [Releases page](https://github.com/lmc-eu/cookie-consent-manager/releases).

--- a/scripts/readme-replace-version.js
+++ b/scripts/readme-replace-version.js
@@ -1,9 +1,12 @@
 const replace = require('replace-in-file');
 const packageJson = require('../package.json');
+// TODO: match just major version after 1.0 release
+const newVersion = packageJson.version.match(/([0-9]\.[0-9])\.[0-9]/)[1];
+
 const options = {
   files: 'README.md',
-  from: /cookie-consent-manager@([0-9]\.[0-9]\.[0-9])/gm,
-  to: `cookie-consent-manager@${packageJson.version}`,
+  from: /cookie-consent-manager@([0-9]\.[0-9])/gm, // TODO: replace with ([0-9]) after 1.0 release
+  to: `cookie-consent-manager@${newVersion}`,
 };
 
 replace(options)


### PR DESCRIPTION
Ref. [#CCM-29](https://jira.int.lmc.cz/browse/CCM-29)

Using this users who will use the "recommended" URL to CDN will get bugfixes.

I also think after 1.0.0 we should also drop the "minor" version from the URL. We comply with semver, so this will mean they will get the latest compatible version. But this is up to discussion, as this might possibly be a bit more risky.