### PR TITLE
Require service name to be passed as the first param

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Load the script and initialize the plugin right before ending `</body>` tag:
 <script defer src="https://cdn.jsdelivr.net/npm/@lmc-eu/cookie-consent-manager@0.5/init.js"></script>
 <script>
 window.addEventListener('load', function () {
-  initLmcCookieConsentManager();
+  initLmcCookieConsentManager('demo.example'); // use the name of your service, like jobs.cz, seduo.pl etc.
 });
 </script>
 ```
@@ -84,7 +84,7 @@ via npm package [@lmc-eu/cookie-consent-manager](https://www.npmjs.com/package/@
     import LmcCookieConsentManager from '@lmc-eu/cookie-consent-manager';
 
     window.addEventListener('load', function () {
-      LmcCookieConsentManager(/* plugin configuration */);
+      LmcCookieConsentManager('demo.example'/* , optional plugin configuration */);
     });
     ```
 
@@ -145,6 +145,7 @@ To execute custom code which depends on cookie consent use callbacks:
 ```js
 // ...
 initLmcCookieConsentManager(
+  'demo.example',
   {
     onAcceptAll: (cookie, cookieConsent) => {
       if (cookieConsent.allowedCategory('functionality')) {
@@ -172,6 +173,7 @@ This feature is enabled by default. If you'd like to disable it, you can do so b
 
 ```js
 initLmcCookieConsentManager(
+  'demo.example',
   {
     config: {
       page_scripts: false
@@ -182,10 +184,12 @@ initLmcCookieConsentManager(
 
 ## Configuration
 
-Optional config parameters could be provided on plugin initialization in the configuration object.
+Optional config parameters could be provided on plugin initialization as the second parameter,
+encapsulated in the configuration object.
 
 ```js
 initLmcCookieConsentManager( // when loaded as a module, these options are passed to `LmcCookieConsentManager()` instead
+  'demo.example', // provide the name of your service, like jobs.cz, seduo.pl etc.
   {
     defaultLang: 'cs',
     autodetectLang: false,

--- a/examples/callbacks.html
+++ b/examples/callbacks.html
@@ -76,6 +76,7 @@
 <script>
   window.addEventListener('load', function () {
     window.ccm = initLmcCookieConsentManager( // note we store cookieConsent instance in global window.ccm variable
+      'github.example',
       {
         autodetectLang: false, // do not detect language from the browser
         defaultLang: 'en', // use 'en' language by default

--- a/examples/configuration.html
+++ b/examples/configuration.html
@@ -75,6 +75,7 @@
 <script>
   window.addEventListener('load', function () {
     window.ccm = initLmcCookieConsentManager( // note we store cookieConsent instance in global window.ccm variable
+      'github.example',
       {
         autodetectLang: false, // do not detect language from the browser
         defaultLang: 'en', // use 'en' language by default

--- a/examples/index.html
+++ b/examples/index.html
@@ -99,6 +99,7 @@
 <script>
   window.addEventListener('load', function () {
     initLmcCookieConsentManager(
+      'github.example',
       {
         autodetectLang: false, // do not detect language from the browser
         defaultLang: 'en', // use 'en' language by default

--- a/examples/theming.html
+++ b/examples/theming.html
@@ -69,6 +69,7 @@
 <script>
   window.addEventListener('load', function () {
     initLmcCookieConsentManager(
+      'github.example',
       {
         autodetectLang: false, // do not detect language from the browser
         defaultLang: 'en', // use 'en' language by default

--- a/src/LmcCookieConsentManager.js
+++ b/src/LmcCookieConsentManager.js
@@ -22,6 +22,7 @@ const defaultOptions = {
 };
 
 /**
+ * @param {string} serviceName - Identifier of the source service (website/application). Must be provided.
  * @param {Object} [args] - Options for cookie consent manager
  * @param {string} [args.defaultLang] - Default language. Must be one of predefined languages.
  * @param {boolean} [args.autodetectLang] - Autodetect language from the browser
@@ -34,7 +35,11 @@ const defaultOptions = {
  * @param {Object} [args.config] - Override default config. See https://github.com/orestbida/cookieconsent/blob/master/Readme.md#all-available-options
  * @returns {Object} Instance of the underlying CookieConsent component. For available API, see https://github.com/orestbida/cookieconsent#apis--configuration-parameters
  */
-const LmcCookieConsentManager = (args) => {
+const LmcCookieConsentManager = (serviceName, args) => {
+  if (!serviceName || serviceName === '' || typeof serviceName !== 'string') {
+    throw new Error('serviceName is a required parameter and must be a string');
+  }
+
   const options = { ...defaultOptions, ...args };
   const {
     defaultLang,


### PR DESCRIPTION
This is the first step of CCM-35. We will require service name to be given on initialization, so that we could submit the consents (CCM-13) in near future, without breaking the API later.