### PR TITLE
Feat: Generate and store consent UUID on accept

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "dependencies": {
     "@lmc-eu/spirit-design-tokens": "^0.4.0",
+    "nanoid": "^3.1.30",
     "vanilla-cookieconsent": "^2.6.1"
   },
   "devDependencies": {

--- a/src/LmcCookieConsentManager.js
+++ b/src/LmcCookieConsentManager.js
@@ -1,4 +1,5 @@
 import 'vanilla-cookieconsent';
+import { nanoid } from 'nanoid';
 
 import { config as configCs } from './languages/cs';
 import { config as configDe } from './languages/de';
@@ -91,6 +92,14 @@ const LmcCookieConsentManager = (serviceName, args) => {
       onAccept(cookie, cookieConsent);
 
       if (isFirstTimeAccept) {
+        const cookieData = cookieConsent.get('data');
+        if (cookieData === null || !('uid' in cookieData)) {
+          cookieConsent.set('data', {
+            value: { serviceName: serviceName, uid: nanoid() },
+            mode: 'update',
+          });
+        }
+
         onFirstAccept(cookie, cookieConsent);
         acceptedOnlyNecessary
           ? onFirstAcceptOnlyNecessary(cookie, cookieConsent)


### PR DESCRIPTION
The next part of CCM-35 after #69.

I thought we would not need uuid library... However from what I've read regarding Math.random(), any uuid function based on it would mean high chance of collisions. And since the traffic this would have and necessity to have uuid really unique, this could be problematic.