### PR TITLE
Chore: Fix building when using crypto in nanoid

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -19,13 +19,7 @@ build({
   bundle: true,
   target: 'es2017',
   outfile: 'dist/LmcCookieConsentManager.mjs',
-  // format: 'esm', // or use platform: neutral and mainFields: ['main']
-  platform: 'neutral', // or use format: 'esm' without  platform and mainFields
-  /**
-   * the "main" field was ignored (main fields must be configured manually when using the "neutral" platform)
-   * because vanilla-cookie-consent is set as `main` in package.json
-   */
-  mainFields: ['main'],
+  format: 'esm',
 }).catch((error) => {
   console.error(error);
   process.exit(1);


### PR DESCRIPTION
  * error: Could not resolve "crypto" (use "platform: 'node'" when
    building for node)

see
- https://github.com/ai/nanoid/issues/278
- https://github.com/evanw/esbuild/issues/387
- https://github.com/ai/nanoid/commit/b7d116c685204f5c9763b0bec96176b8b428bf3c
