### PR TITLE
Refactor: Extract assemble config into variable

### DIFF
--- a/src/LmcCookieConsentManager.js
+++ b/src/LmcCookieConsentManager.js
@@ -71,7 +71,7 @@ const LmcCookieConsentManager = (serviceName, args) => {
     uk: configUk({ companyNames }),
   };
 
-  cookieConsent.run({
+  const cookieConsentConfig = {
     auto_language: autodetectLang, // Enable detection from navigator.language
     autorun: true, // Show the cookie consent banner as soon as possible
     cookie_expiration: 365, // 1 year
@@ -127,7 +127,9 @@ const LmcCookieConsentManager = (serviceName, args) => {
     languages,
     // override default config if necessary
     ...config,
-  });
+  };
+
+  cookieConsent.run(cookieConsentConfig);
 
   return cookieConsent;
 };


### PR DESCRIPTION
The length of `run()` call is now >50 lines long, so this is hard to read and code smell.

Also, I sometimes want to dump the assembled config, which is now much easier.

(BTW In the future I think it may also be inevitable to move the whole config object assembly to custom method.)