### PR TITLE
Chore: Cache yarn dependencies to increase GH Actions jobs speed

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -22,7 +22,7 @@ jobs:
         run: git fetch --no-tags --depth=50 origin main
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        uses: bahmutov/npm-install@v1
 
       - name: Run Commitlint
         run: yarn commitlint --color --verbose --from $(git merge-base origin/main HEAD)

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,7 @@ jobs:
         run: git fetch --no-tags --depth=50 origin main
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        uses: bahmutov/npm-install@v1
 
       - name: Lint
         run: yarn lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
         run: git fetch --no-tags --depth=50 origin main
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        uses: bahmutov/npm-install@v1
 
       - name: Test
         run: yarn test:unit


### PR DESCRIPTION
What do you think, is this worth it? [The action ](https://github.com/bahmutov/npm-install)caches the yarn cache folder, in invalidates if hash of yarn.lock file changes.

Despite name of the action, it recognizes yarn and run `yarn --frozen-lockfile`, see [log output](https://github.com/lmc-eu/cookie-consent-manager/runs/4290791770?check_suite_focus=true#step:5:12). 

It decreases each yarn `Install dependencies` step by ~10 seconds. 