### PR TITLE
Feat: Option to define URL to the API

### DIFF
--- a/examples/configuration.html
+++ b/examples/configuration.html
@@ -80,7 +80,7 @@
         autodetectLang: false, // do not detect language from the browser
         defaultLang: 'en', // use 'en' language by default
         companyNames: ['LMC', 'Some Other Company', 'ACME'], // define custom company names to be shown in the consent text
-        enableConsentSubmit: true, // submit consents to the API; do not use this option unless you have been explicitly guided to do so
+        enableConsentSubmit: 'https://ccm.lmc.cz/local-data-acceptation-data-entries?Spot=(arch,test)', // submit consents to the API; do not use this option unless you have been explicitly guided to do so
         config: { // override default config of the underlying library, see https://github.com/orestbida/cookieconsent#all-available-options
           delay: 500, // show cookie consent banner after 500ms
           page_scripts: false, // disable third-party script management, see https://github.com/lmc-eu/cookie-consent-manager#third-party-scripts-loaded-via-script

--- a/src/LmcCookieConsentManager.js
+++ b/src/LmcCookieConsentManager.js
@@ -9,12 +9,12 @@ import { config as configPl } from './languages/pl';
 import { config as configRu } from './languages/ru';
 import { config as configSk } from './languages/sk';
 import { config as configUk } from './languages/uk';
-import submitConsent from './dataCollector';
+import submitConsent from './consentCollector';
 
 const defaultOptions = {
   defaultLang: 'cs',
   autodetectLang: true,
-  enableConsentSubmit: false,
+  consentCollectorApiUrl: 'https://ccm.lmc.cz/local-data-acceptation-data-entries',
   onFirstAccept: (cookie, cookieConsent) => {},
   onFirstAcceptOnlyNecessary: (cookie, cookieConsent) => {},
   onFirstAcceptAll: (cookie, cookieConsent) => {},
@@ -30,7 +30,7 @@ const defaultOptions = {
  * @param {Object} [args] - Options for cookie consent manager
  * @param {string} [args.defaultLang] - Default language. Must be one of predefined languages.
  * @param {boolean} [args.autodetectLang] - Autodetect language from the browser
- * @param {boolean} [args.enableConsentSubmit] - Submit user consent information to the API
+ * @param {?string} [args.consentCollectorApiUrl] - URL of the API where user consent information should be sent. Null to disable.
  * @param {function} [args.onFirstAccept] - Callback to be executed right after any consent is just accepted
  * @param {function} [args.onFirstAcceptOnlyNecessary] - Callback to be executed right after only necessary cookies are accepted
  * @param {function} [args.onFirstAcceptAll] - Callback to be executed right after all cookies are accepted
@@ -50,7 +50,7 @@ const LmcCookieConsentManager = (serviceName, args) => {
   const {
     defaultLang,
     autodetectLang,
-    enableConsentSubmit,
+    consentCollectorApiUrl,
     onFirstAccept,
     onFirstAcceptOnlyNecessary,
     onFirstAcceptAll,
@@ -118,8 +118,8 @@ const LmcCookieConsentManager = (serviceName, args) => {
           });
         }
 
-        if (enableConsentSubmit) {
-          submitConsent(cookieConsent, acceptedOnlyNecessary);
+        if (consentCollectorApiUrl !== null) {
+          submitConsent(consentCollectorApiUrl, cookieConsent, acceptedOnlyNecessary);
         }
 
         onFirstAccept(cookie, cookieConsent);

--- a/src/consentCollector.js
+++ b/src/consentCollector.js
@@ -1,13 +1,14 @@
 /**
  * Submit information about consent level given by the user.
  *
+ * @param {string} consentCollectorApiUrl
  * @param {Object} cookieConsent
  * @param {boolean} acceptedOnlyNecessary
  */
-export const submitConsent = (cookieConsent, acceptedOnlyNecessary) => {
+export const submitConsent = (consentCollectorApiUrl, cookieConsent, acceptedOnlyNecessary) => {
   const payload = buildPayload(cookieConsent, acceptedOnlyNecessary);
 
-  postDataToApi(payload);
+  postDataToApi(consentCollectorApiUrl, payload);
 };
 
 /**
@@ -40,14 +41,12 @@ const buildPayload = (cookieConsent, acceptedOnlyNecessary) => {
 };
 
 /**
+ * @param {string} apiUrl
  * @param {Object} payload
  * @return {Promise<any>}
  */
-const postDataToApi = async (payload) => {
-  const dataCollectorUrl =
-    'https://ccm.lmc.cz/local-data-acceptation-data-entries?Spot=(arch,test)'; // TODO: remove test spot after beta
-
-  const response = await fetch(dataCollectorUrl, {
+const postDataToApi = async (apiUrl, payload) => {
+  const response = await fetch(apiUrl, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/vnd.api+json',


### PR DESCRIPTION
This is a variant of #73. This adds option to use custom API url, and also an option to disable it by providing null. 

The use cases are:
* default - send consents, will use `https://ccm.lmc.cz/local-data-acceptation-data-entries`
* disable sending - use `null`
* use custom URL / Spot - provide `https://ccm.lmc.cz/local-data-acceptation-data-entries?Spot=(arch,test)`

Sending separately, as this is kind of "request for comments".