### PR TITLE
Fix: Make `font-family` fallback actually work as documented

### DIFF
--- a/src/scss/_theme.scss
+++ b/src/scss/_theme.scss
@@ -18,7 +18,7 @@
     // ==========
 
     --lmcccm-p-base-font-size: var(--lmcccm-base-font-size, #{tokens.$font-size-base});
-    --lmcccm-p-font-family: var(--lmcccm-font-family, #{tokens.$font-family-default});
+    --lmcccm-p-font-family: var(--lmcccm-font-family, #{tokens.$font-family-default}), inherit;
 
     //
     // Light Mode


### PR DESCRIPTION
This fix prevents plugin's UI from being rendered with browser's default font (typically Times New Roman) when `Inter` font is not downloadable or installed.

Why `font-family` is not inherited when `Inter` font is not present? When `font-family` is obtained via `var()` function and the font is not available, entire declaration is invalid and — as opposed to direct declaration `font-family: Inter` — the value of `font-family` is reset to browser default.

> On the other hand, if you’re asking why a var() expression doesn’t default to the next best-cascaded value, that’s because by the time the var() expression is evaluated, there are no other values to fall back to, because every other declaration in the cascade has been erased.

https://stackoverflow.com/a/48081355

https://drafts.csswg.org/css-variables/#invalid-at-computed-value-time