### PR TITLE
Feat: Submit to API also current language and cookie expiration #CCM-41

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@lmc-eu/spirit-design-tokens": "^0.4.0",
     "nanoid": "^3.1.30",
-    "vanilla-cookieconsent": "^2.7.0-rc1"
+    "vanilla-cookieconsent": "^2.7.0-rc3"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.0",

--- a/src/consentCollector.js
+++ b/src/consentCollector.js
@@ -35,6 +35,8 @@ const buildPayload = (cookieConsent, acceptedOnlyNecessary) => {
         rejected_categories: rejectedCategories,
         revision: cookieConsent.get('revision'),
         source: cookieData.serviceName,
+        language: cookieConsent.getConfig('current_lang'),
+        days_of_acceptation: cookieConsent.getConfig('cookie_expiration'),
       },
     },
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5709,10 +5709,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-cookieconsent@^2.7.0-rc1:
-  version "2.7.0-rc1"
-  resolved "https://registry.yarnpkg.com/vanilla-cookieconsent/-/vanilla-cookieconsent-2.7.0-rc1.tgz#e81c63a68c54d7ca02126eb4412b6f555aac53c4"
-  integrity sha512-wsiCNMqB1oqplOAKw8JhpWpC0vSfMW88WiieaDcq9dLykZ0lguW8nXt5MZsRNmFCDg0XQFGzaltiXPsZCGlGWg==
+vanilla-cookieconsent@^2.7.0-rc3:
+  version "2.7.0-rc3"
+  resolved "https://registry.yarnpkg.com/vanilla-cookieconsent/-/vanilla-cookieconsent-2.7.0-rc3.tgz#7bf4170010e248cef0b3ba5219167ebd6eb63475"
+  integrity sha512-ZBZ2qO7DVdh7R3g3WUgKsvZEvYJWa339aTFAsOJmZBqBIsGwD2SL8C0DCkiE1suMA54twWbQAeVzJfiB0I8fKg==
 
 vfile-message@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
The getter was added in the vanilla component (https://github.com/orestbida/cookieconsent/pull/113), allowing us to read the values from the instance.

However, this will now not work properly, because of https://github.com/orestbida/cookieconsent/pull/120 .

So we must wait until this is resolved.