### PR TITLE
Feat: Autodetect language based on the value of <html lang=...>

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,8 @@ initLmcCookieConsentManager( // when loaded as a module, these options are passe
 
 | Option          | Type        | Default value                   | Description                                                                                                                               |
 |-----------------|-------------|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `autodetectLang`| boolean     | true                            | Autodetect language based on the value of `<html lang="...">`. If autodetect fails or if unsupported language is detected, fallback to `defaultLang`.<br>When disabled, force language to `defaultLang`. |
 | `defaultLang`   | string      | 'cs'                            | Default language. One of `cs`, `de`, `en`, `hu`, `pl`, `ru`, `sk`, `uk`. This language will be used when autodetect is disabled or when it fails. |
-| `autodetectLang`| boolean     | true                            | Autodetect language from the browser. If autodetect fails or if unsupported language is detected, fallback to `defaultLang`.<br>When disabled, force language to `defaultLang`. |
 | `companyNames`  | array       | ['LMC']                         | Array of strings with company names. Adjust only when the consent needs to be given to multiple companies. [See example][examples-configuration]. |
 | `consentCollectorApiUrl`| ?string | 'https://ccm.lmc.cz/(...)'  | URL of the API where user consent information is sent. Null to disable sending data to the API. |
 | `config`        | Object      | {}                              | Override default config of the underlying library. For all parameters see [original library](https://github.com/orestbida/cookieconsent#all-available-options). |

--- a/examples/callbacks.html
+++ b/examples/callbacks.html
@@ -78,8 +78,6 @@
     window.ccm = initLmcCookieConsentManager( // note we store cookieConsent instance in global window.ccm variable
       'github.example',
       {
-        autodetectLang: false, // do not detect language from the browser
-        defaultLang: 'en', // use 'en' language by default
         consentCollectorApiUrl: 'https://ccm.lmc.cz/local-data-acceptation-data-entries?Spot=(public,demo)', // override default URL for demo purposes; do not set custom consentCollectorApiUrl unless you have been explicitly guided to do so!
         onAccept: (cookie, cookieConsent) => { // any type of consent detected
           markCallbackCalled('onAccept');

--- a/examples/configuration.html
+++ b/examples/configuration.html
@@ -77,8 +77,8 @@
     window.ccm = initLmcCookieConsentManager( // note we store cookieConsent instance in global window.ccm variable
       'github.example',
       {
-        autodetectLang: false, // do not detect language from the browser
-        defaultLang: 'en', // use 'en' language by default
+        autodetectLang: false, // do not detect language from the `<html lang="...">` value
+        defaultLang: 'en', // force use of 'en' language instead
         companyNames: ['LMC', 'Some Other Company', 'ACME'], // define custom company names to be shown in the consent text
         consentCollectorApiUrl: 'https://ccm.lmc.cz/local-data-acceptation-data-entries?Spot=(public,demo)', // override default URL for demo purposes; do not set custom consentCollectorApiUrl unless you have been explicitly guided to do so!
         config: { // override default config of the underlying library, see https://github.com/orestbida/cookieconsent#all-available-options

--- a/examples/index.html
+++ b/examples/index.html
@@ -101,8 +101,6 @@
     initLmcCookieConsentManager(
       'github.example',
       {
-        autodetectLang: false, // do not detect language from the browser
-        defaultLang: 'en', // use 'en' language by default
         consentCollectorApiUrl: 'https://ccm.lmc.cz/local-data-acceptation-data-entries?Spot=(public,demo)', // override default URL for demo purposes; do not set custom consentCollectorApiUrl unless you have been explicitly guided to do so!
         onAccept: (cookie, cookieConsent) => { // any type of consent (including "only necessary") detected
           document.getElementById('onaccept-content').innerHTML = JSON.stringify(cookie)

--- a/examples/theming.html
+++ b/examples/theming.html
@@ -71,8 +71,6 @@
     initLmcCookieConsentManager(
       'github.example',
       {
-        autodetectLang: false, // do not detect language from the browser
-        defaultLang: 'en', // use 'en' language by default
         consentCollectorApiUrl: 'https://ccm.lmc.cz/local-data-acceptation-data-entries?Spot=(public,demo)', // override default URL for demo purposes; do not set custom consentCollectorApiUrl unless you have been explicitly guided to do so!
       }
     );

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@lmc-eu/spirit-design-tokens": "^0.4.0",
     "nanoid": "^3.1.30",
-    "vanilla-cookieconsent": "^2.6.1"
+    "vanilla-cookieconsent": "^2.7.0-rc1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.0",

--- a/src/LmcCookieConsentManager.js
+++ b/src/LmcCookieConsentManager.js
@@ -29,7 +29,7 @@ const defaultOptions = {
  * @param {string} serviceName - Identifier of the source service (website/application). Must be provided.
  * @param {Object} [args] - Options for cookie consent manager
  * @param {string} [args.defaultLang] - Default language. Must be one of predefined languages.
- * @param {boolean} [args.autodetectLang] - Autodetect language from the browser
+ * @param {boolean} [args.autodetectLang] - Autodetect language from the value of `<html lang="...">`
  * @param {?string} [args.consentCollectorApiUrl] - URL of the API where user consent information should be sent. Null to disable.
  * @param {function} [args.onFirstAccept] - Callback to be executed right after any consent is just accepted
  * @param {function} [args.onFirstAcceptOnlyNecessary] - Callback to be executed right after only necessary cookies are accepted
@@ -76,7 +76,7 @@ const LmcCookieConsentManager = (serviceName, args) => {
   };
 
   const cookieConsentConfig = {
-    auto_language: autodetectLang, // Enable detection from navigator.language
+    auto_language: autodetectLang ? 'document' : null, // Autodetect language based on `<html lang="...">` value
     autorun: true, // Show the cookie consent banner as soon as possible
     cookie_expiration: 365, // 1 year
     cookie_name: cookieName, // Predefined cookie name. Do not override.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5709,10 +5709,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-cookieconsent@^2.6.1:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/vanilla-cookieconsent/-/vanilla-cookieconsent-2.6.2.tgz#9ef7d3ecb3ff14f8fe66bd9d0f657a3aee78fd25"
-  integrity sha512-BaO3QfKEMCYNovobpvxSESDLZgRODYuUjJbKOjYEjrC7FMXKdGGSk2+xInb4QIMybmorjPSNk8jnTn1WvIlKdA==
+vanilla-cookieconsent@^2.7.0-rc1:
+  version "2.7.0-rc1"
+  resolved "https://registry.yarnpkg.com/vanilla-cookieconsent/-/vanilla-cookieconsent-2.7.0-rc1.tgz#e81c63a68c54d7ca02126eb4412b6f555aac53c4"
+  integrity sha512-wsiCNMqB1oqplOAKw8JhpWpC0vSfMW88WiieaDcq9dLykZ0lguW8nXt5MZsRNmFCDg0XQFGzaltiXPsZCGlGWg==
 
 vfile-message@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
Instead of autodetection based on the browser language, which I don't think will be used by anyone in LMC, we will base the detection on the document root element (`<html lang="...">`), whats is a new option in vanilla cookieconsent 2.7.