### PR TITLE
Docs/improve font instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ anywhere in your stylesheet (the order of which is not important):
 }
 ```
 
+[👀 See theming example][examples-theming]
+
 <details>
 <summary>Full list of available CSS custom properties:</summary>
 
@@ -439,3 +441,4 @@ for more information.
 [examples]: https://lmc-eu.github.io/cookie-consent-manager/examples/
 [examples-callbacks]: https://lmc-eu.github.io/cookie-consent-manager/examples/callbacks.html
 [examples-configuration]: https://lmc-eu.github.io/cookie-consent-manager/examples/configuration.html
+[examples-theming]: https://lmc-eu.github.io/cookie-consent-manager/examples/theming.html

--- a/README.md
+++ b/README.md
@@ -9,10 +9,18 @@ The package is a wrapper around [Cookie Consent] by [Orest Bida].
 
 ## Basic usage
 
-Load default CSS in your `<head>`:
+Make assets load faster by placing pre-connect headers right after `<meta charset>` in your `<head>`:
 
 ```html
 <link rel="preconnect" href="https://cdn.jsdelivr.net">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+```
+
+Load default CSS along with your styles in `<head>`:
+
+```html
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@lmc-eu/cookie-consent-manager@0.7/LmcCookieConsentManager.min.css">
 ```
 
@@ -30,22 +38,6 @@ window.addEventListener('load', function () {
 This will load the plugin from CDN and initialize the plugin with default settings.
 [👀 See example][examples].
 
-## Use default web font, or not?
-
-If you are going to use the plugin with the default theme, you may also want to load default Spirit web font
-which is used by the plugin:
-
-```html
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap">
-```
-
-If Inter font is not provided (or installed in user's system), all texts in cookie consent UI default to whatever
-current `font-family` is set to. As you cannot predict what fonts are available on user's side, and because this
-behavior may change in future versions of Spirit Design Tokens, we encourage you either to load the default web font
-as shown above or to explicitly specify the desired font yourself (head to [Theming](#theming) to see how).
-
 ## Loading the plugin
 
 ### Via CDN or static file
@@ -54,6 +46,7 @@ You can load the plugin from a CDN, as in the basic example above.
 
 ```html
 <!-- Note we use version "cookie-consent-manager@0.7", which points the latest version of this series (including bugfix releases) -->
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@lmc-eu/cookie-consent-manager@0.7/LmcCookieConsentManager.min.css">
 <script defer src="https://cdn.jsdelivr.net/npm/@lmc-eu/cookie-consent-manager@0.7/init.js"></script>
 ```
@@ -96,13 +89,28 @@ via npm package [@lmc-eu/cookie-consent-manager](https://www.npmjs.com/package/@
    ```
    or in your Sass stylesheet:
    ```scss
-   @use 'node_modules/@lmc-eu/cookie-consent-manager/LmcCookieConsentManager.css';
+   @use "node_modules/@lmc-eu/cookie-consent-manager/LmcCookieConsentManager.css";
    ```
 
    Please mind the `.css` extension used in the Sass example. Using the provided `.scss` stylesheet is
    recommended only for projects that are built [with Spirit Design System](#with-spirit-design-system).
 
-   See below for [theming customization options](#theming).
+   See below for [theme customization options](#theming).
+
+4. For projects that are **NOT** built with [Spirit Design System]:
+
+   1. Include default font in your HTML:
+      ```html
+      <link rel="preconnect" href="https://fonts.googleapis.com">
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap">
+      ```
+      or in your Sass stylesheet:
+      ```scss
+      @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap");
+      ```
+
+   2. Or [switch to custom font](#custom-font) that matches the design of your project.
 
 #### Legacy import
 
@@ -249,7 +257,7 @@ Each configured callback receives two params:
 
 If your project uses [Spirit Design System], you are almost done!
 
-All you need to do is to add this plugin's SCSS to your Sass pipeline:
+All you need to do is to add this plugin's SCSS to your Sass pipeline and use it **instead** of the default CSS:
 
 ```scss
 // my-project.scss
@@ -259,7 +267,10 @@ All you need to do is to add this plugin's SCSS to your Sass pipeline:
 @use '@lmc-eu/cookie-consent-manager/LmcCookieConsentManager';
 ```
 
-Now set up a [Sass load path] so the Sass compiler can find stylesheets located in the `node_modules` directory
+<details>
+<summary>Make sure you have <code>node_modules</code> and path to your design tokens in your Sass include paths.</summary>
+
+Set up [Sass load path] so the Sass compiler can find stylesheets located in the `node_modules` directory
 (you will already have a path to your design tokens there, as required by [Spirit Web]):
 
 ```sh
@@ -289,15 +300,25 @@ Or with webpack:
 },
 ```
 
+</details>
+
 **Note:** `sass` v1.23 or higher is required to be able to compile the new Sass modules syntax. You may need to migrate
 to [`sass`][sass] since all other Sass compilers (and the old `@import` rule) are now [deprecated][sass modules].
 
 ### Without Spirit Design System
 
+Handful of CSS custom properties are available for you to customize the UI to make it match the design of your site.
+For example, to change text color of cookie consent UI, load the [default CSS](#basic-usage) and add the following code
+anywhere in your stylesheet (the order of which is not important):
+
+```css
+:root {
+  --lmcccm-text: #333;
+}
+```
 
 <details>
-<summary>Following CSS custom properties are available for you to customize the UI:</summary>
-
+<summary>Full list of available CSS custom properties:</summary>
 
 | CSS custom property                   | Description                                             |
 |---------------------------------------|---------------------------------------------------------|
@@ -321,22 +342,31 @@ to [`sass`][sass] since all other Sass compilers (and the old `@import` rule) ar
 | `--lmcccm-btn-secondary-active-bg`    | Secondary button background color in active state       |
 | `--lmcccm-btn-secondary-active-text`  | Secondary button text color in active state             |
 
-Change their values to adjust cookie consent UI to match the design of your site:
-
-```css
-:root {
-  --lmcccm-font-family: 'Open Sans', arial, sans-serif;
-}
-```
 </details>
+
+### Custom font
+
+Default cookie consent design uses Inter font loaded via Google Fonts as shown in the [basic](#basic-usage) example.
+If you are not using cookie consent with the default design, additional steps may be necessary for you:
+
+- If your project is built with Spirit Design System, you already have the correct font linked in your HTML or CSS.
+- If your project is _not_ built with Spirit Design System, you can switch to any font of your choice:
+  ```css
+  :root {
+    --lmcccm-font-family: "Open Sans", arial, sans-serif;
+  }
+  ```
+
+If you use custom font like this, make sure you don't load the default Inter font and that you use
+`<link rel="preconnect" ...>` only to actually needed domains.
 
 ### Dark mode
 
 Add `c_darkmode` CSS class to `<body>` to enable dark mode. It reuses [Spirit Design Tokens], so if your project is
 built with Spirit, applying the `c_darkmode` class is all you need to do and dark mode will work for you out-of-the-box.
 
-If your project does _not_ use Spirit, you still may adjust exposed CSS custom properties as described above,
-this time scoped to the `.c_darkmode` class:
+If your project does _not_ use Spirit, you still may adjust exposed CSS custom properties as described
+[above](#without-spirit-design-system), this time scoped to the `.c_darkmode` class:
 
 ```css
 .c_darkmode {

--- a/README.md
+++ b/README.md
@@ -322,8 +322,8 @@ anywhere in your stylesheet (the order of which is not important):
 
 | CSS custom property                   | Description                                             |
 |---------------------------------------|---------------------------------------------------------|
-| `--lmcccm-base-font-size`             | Base font size                                          |
 | `--lmcccm-font-family`                | Base font family                                        |
+| `--lmcccm-base-font-size`             | Base font size                                          |
 | `--lmcccm-bg`                         | Bar background color                                    |
 | `--lmcccm-text`                       | Text color                                              |
 | `--lmcccm-link-text`                  | Link text color                                         |
@@ -335,11 +335,8 @@ anywhere in your stylesheet (the order of which is not important):
 | `--lmcccm-btn-primary-hover-text`     | Primary button text color on hover                      |
 | `--lmcccm-btn-primary-active-bg`      | Primary button background color in active state         |
 | `--lmcccm-btn-primary-active-text`    | Primary button text color in active state               |
-| `--lmcccm-btn-secondary-bg`           | Secondary button background color                       |
 | `--lmcccm-btn-secondary-text`         | Secondary button text color                             |
-| `--lmcccm-btn-secondary-hover-bg`     | Secondary button background color on hover              |
 | `--lmcccm-btn-secondary-hover-text`   | Secondary button text color on hover                    |
-| `--lmcccm-btn-secondary-active-bg`    | Secondary button background color in active state       |
 | `--lmcccm-btn-secondary-active-text`  | Secondary button text color in active state             |
 
 </details>

--- a/README.md
+++ b/README.md
@@ -329,10 +329,16 @@ anywhere in your stylesheet (the order of which is not important):
 | `--lmcccm-link-text`                  | Link text color                                         |
 | `--lmcccm-link-hover-text`            | Link text color on hover                                |
 | `--lmcccm-link-active-text`           | Link text color in active state                         |
+| `--lmcccm-btn-border-width`           | Button border width                                     |
+| `--lmcccm-btn-border-style`           | Button border style                                     |
+| `--lmcccm-btn-border-radius`          | Button border radius                                    |
+| `--lmcccm-btn-primary-border`         | Primary button border color                             |
 | `--lmcccm-btn-primary-bg`             | Primary button background color                         |
 | `--lmcccm-btn-primary-text`           | Primary button text color                               |
+| `--lmcccm-btn-primary-hover-border`   | Primary button border color on hover                    |
 | `--lmcccm-btn-primary-hover-bg`       | Primary button background color on hover                |
 | `--lmcccm-btn-primary-hover-text`     | Primary button text color on hover                      |
+| `--lmcccm-btn-primary-active-border`  | Primary button border color in active state             |
 | `--lmcccm-btn-primary-active-bg`      | Primary button background color in active state         |
 | `--lmcccm-btn-primary-active-text`    | Primary button text color in active state               |
 | `--lmcccm-btn-secondary-text`         | Secondary button text color                             |

--- a/examples/callbacks.html
+++ b/examples/callbacks.html
@@ -16,50 +16,62 @@
 
     <link rel="stylesheet" href="../dist/LmcCookieConsentManager.min.css"><!-- You will load this from CDN instead -->
 </head>
-<body style="padding-bottom: 420px">
+<body style="padding-bottom: 380px">
 
-<header class="container mt-4">
-    <h1>LMC Cookie Consent Manager</h1>
+<header class="container">
+    <div class="d-flex flex-column align-items-center flex-md-row py-3">
+        <a href="." class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-dark text-decoration-none">
+            <svg class="me-3" width="67" height="52" viewBox="0 0 67 52">
+                <path fill="#12bcca" d="M3.3 49.2c-1.8.3-5.4 2.1-1.6 2.7 3.9.7 44.4-3.6 63-1.5 2.9.4 2.3-.8-.6-1a472 472 0 00-60.8-.2" />
+                <path fill="#002d5c" d="M23 39.4c.7-.3 1.7.8 1 1.6a1.5 1.5 0 01-.4.2c-2.3.8-9.5 2.6-12.1-3.5-.9.9-1.7 1.4-2.6 2-6.3 4.5-6.4 2.5-6.4 2.4-.3-1.8 1.4-2 1.4-2s3.4-.7 6.8-4.1c-.7-3.3-1.6-10-.7-15.5C11.7 8.8 16 2.5 20.2.8c4.1-1.4 5.2 1.1 5.5 3.2 1 5-.3 15.3-12.5 31.8.6 2.1 1 3.6 2.7 4.6 3.4 2 6.8-.9 7.2-1m-10.3-5.2c1.8-2 7-10.3 8.3-13 4.2-9.5 3.9-17 2.2-18.2C18.8-.2 9.6 23.2 12.7 34.2M57.4 31.6c-3.4 5-8 6.5-8 6.5s-7 2.8-9 .1c-2.2-2.6.6-7 1.1-7.9.5-.7 2.6-2.8 2.6-1.4 0 1.2-.5 3.5 1 2.9.2-.2.7-.7 1-1.3.5-1 1-3-.8-4-2.8-1.7-5.7 1.7-6.5 4.3-.6 1.8-1.6 5.2.3 7.4 4.5 5 13.2 2.8 19.3-2 4.6-3.8 2.4-9.6-1-4.6" />
+                <path fill="#002d5c" d="M36.6 39.6a3 3 0 01-1.7-2.7c0-3.4 1.6-6.5 2-7.3.3-.8-1.3-2-3.1-1.5-1.9.4-3.3 2.8-3.6 3.2-.3.4-.8.6-.5-.5l.2-.6c0-.3.1-.6-.1-.9-.3-.5-2.4-.8-3.6 0-1.5.8-2.6 3.3-2.8 2.3 0 0 0-.5-.2-.6-.1-.3-1-.5-1.7-.1-.8.4-1.2 1.4-1.5 1.8l-.2.4-.5 1-1.2 2.2c-.2.4-.1.8.1 1.1.2.3 1 .7 1.2.1l.4-.7.6-1.4.7-1.6c.3-.4 1-.7.8.2 0 .5-.3 1.4-.5 2 0 .4.6 1.1 1-.1a13 13 0 012.4-3.7c.4-.4 1.2-.6 1 .2-.2 1.5-.2 3.6.2 5.5.4 1.8 2 2.1 2.7-.5.5-1.5 1.8-4.4 2.9-6 .8-1.2 2.2-1.5 1.6-.2l-.8 2.4c-.3 1.4-.7 3.7-.1 5 .7 1.7 3.8 2.9 4.4 2.2.4-.4.4-1 0-1.2" />
+            </svg>
+            <span class="fs-5">Cookie Consent Manager</span>
+        </a>
+        <div>
+            <a class="btn btn-outline-primary me-2" href="https://github.com/lmc-eu/cookie-consent/#readme" target="_blank">Documentation</a>
+            <a class="btn btn-primary" href="https://github.com/lmc-eu/cookie-consent/releases" target="_blank">Download</a>
+        </div>
+    </div>
 </header>
 
-<div class="container mt-4">
-    <ul class="nav nav-tabs">
-        <li class="nav-item">
-            <a class="nav-link" href=".">Basic example</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link" href="./configuration.html">Extended configuration</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link active" href="./callbacks.html">Callbacks</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link" href="./theming.html">Theming</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link" href="https://github.com/lmc-eu/cookie-consent/" target="_blank">Documentation <i class="bi bi-box-arrow-up-right"></i></a>
-        </li>
-    </ul>
-</div>
+<main>
+    <div class="py-5 bg-light text-center">
+        <div class="container">
 
-<main class="container mt-4">
-    <div class="row">
-        <div class="col">
-            <p class="lead">
+            <h1 class="display-1 mt-md-3">Callbacks</h1>
+            <p class="lead mb-4 mb-md-5">
                 This is an example of configurable callbacks.
             </p>
 
-            <p>
-                <a href="" class="btn btn-warning" onclick="removeCookieAndReload();">
-                    Remove <code>lmc_ccm</code> cookie and reload
-                </a>
-            </p>
+            <ul class="nav nav-pills justify-content-center mb-3">
+                <li class="nav-item">
+                    <a class="nav-link" href=".">Basic example</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="./configuration.html">Extended configuration</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link active" href="./callbacks.html">Callbacks</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="./theming.html">Theming</a>
+                </li>
+            </ul>
 
-            <h3 class="mt-4">Callbacks</h3>
+        </div>
+    </div>
+    <div id="reset" class="position-fixed bottom-0 end-0 me-5 mb-5" style="z-index: 1" hidden>
+        <a href="" class="btn btn-lg btn-warning shadow-lg" onclick="removeCookieAndReload();" data-bs-toggle="tooltip" data-bs-html="true" title="Remove <code>lmc_ccm</code> cookie and reload">
+            <i class="bi bi-arrow-clockwise"></i>
+            Reset cookie
+        </a>
+    </div>
+    <div class="container py-5">
+        <div class="row justify-content-lg-center">
+            <div class="col col-lg-10 col-xl-8">
 
-            <div class="row">
-                <div class="col-md-6 col-xs-12">
-
+                <h2 class="mt-md-3 mb-3">Callbacks</h2>
                 <ul class="list-group">
                     <li class="list-group-item" id="callback-onAccept">onAccept</li>
                     <li class="list-group-item" id="callback-onAcceptAll">onAcceptAll</li>
@@ -68,11 +80,20 @@
                     <li class="list-group-item" id="callback-onFirstAcceptAll">onFirstAcceptAll</li>
                     <li class="list-group-item" id="callback-onFirstAcceptOnlyNecessary">onFirstAcceptOnlyNecessary</li>
                 </ul>
-                </div>
+
             </div>
         </div>
     </div>
 </main>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+<script>
+    // Bootstrap Tooltips
+    const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+    const tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+        return new bootstrap.Tooltip(tooltipTriggerEl)
+    })
+</script>
 
 <script defer src="../dist/init.js"></script>
 <script>
@@ -83,6 +104,7 @@
         consentCollectorApiUrl: 'https://ccm.lmc.cz/local-data-acceptation-data-entries?Spot=(public,demo)', // override default URL for demo purposes; do not set custom consentCollectorApiUrl unless you have been explicitly guided to do so!
         onAccept: (cookie, cookieConsent) => { // any type of consent detected
           markCallbackCalled('onAccept');
+          document.getElementById('reset').removeAttribute('hidden'); // reveal Reset cookie button
         },
         onAcceptAll: (cookie, cookieConsent) => { // consent for all cookies detected
           markCallbackCalled('onAcceptAll');

--- a/examples/callbacks.html
+++ b/examples/callbacks.html
@@ -2,19 +2,21 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="preconnect" href="https://cdn.jsdelivr.net">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
     <title>Cookie Consent Manager – callbacks example</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.0/font/bootstrap-icons.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap">
     <script src="./functions.js" defer></script>
 
-    <link rel="stylesheet" href="../dist/LmcCookieConsentManager.css"><!-- You will load this from CDN instead -->
+    <link rel="stylesheet" href="../dist/LmcCookieConsentManager.min.css"><!-- You will load this from CDN instead -->
 </head>
-<body>
+<body style="padding-bottom: 420px">
 
 <header class="container mt-4">
     <h1>LMC Cookie Consent Manager</h1>

--- a/examples/configuration.html
+++ b/examples/configuration.html
@@ -16,62 +16,88 @@
 
     <link rel="stylesheet" href="../dist/LmcCookieConsentManager.min.css"><!-- You will load this from CDN instead -->
 </head>
-<body style="padding-bottom: 420px">
+<body style="padding-bottom: 380px">
 
-<header class="container mt-4">
-    <h1>LMC Cookie Consent Manager</h1>
+<header class="container">
+    <div class="d-flex flex-column align-items-center flex-md-row py-3">
+        <a href="." class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-dark text-decoration-none">
+            <svg class="me-3" width="67" height="52" viewBox="0 0 67 52">
+                <path fill="#12bcca" d="M3.3 49.2c-1.8.3-5.4 2.1-1.6 2.7 3.9.7 44.4-3.6 63-1.5 2.9.4 2.3-.8-.6-1a472 472 0 00-60.8-.2" />
+                <path fill="#002d5c" d="M23 39.4c.7-.3 1.7.8 1 1.6a1.5 1.5 0 01-.4.2c-2.3.8-9.5 2.6-12.1-3.5-.9.9-1.7 1.4-2.6 2-6.3 4.5-6.4 2.5-6.4 2.4-.3-1.8 1.4-2 1.4-2s3.4-.7 6.8-4.1c-.7-3.3-1.6-10-.7-15.5C11.7 8.8 16 2.5 20.2.8c4.1-1.4 5.2 1.1 5.5 3.2 1 5-.3 15.3-12.5 31.8.6 2.1 1 3.6 2.7 4.6 3.4 2 6.8-.9 7.2-1m-10.3-5.2c1.8-2 7-10.3 8.3-13 4.2-9.5 3.9-17 2.2-18.2C18.8-.2 9.6 23.2 12.7 34.2M57.4 31.6c-3.4 5-8 6.5-8 6.5s-7 2.8-9 .1c-2.2-2.6.6-7 1.1-7.9.5-.7 2.6-2.8 2.6-1.4 0 1.2-.5 3.5 1 2.9.2-.2.7-.7 1-1.3.5-1 1-3-.8-4-2.8-1.7-5.7 1.7-6.5 4.3-.6 1.8-1.6 5.2.3 7.4 4.5 5 13.2 2.8 19.3-2 4.6-3.8 2.4-9.6-1-4.6" />
+                <path fill="#002d5c" d="M36.6 39.6a3 3 0 01-1.7-2.7c0-3.4 1.6-6.5 2-7.3.3-.8-1.3-2-3.1-1.5-1.9.4-3.3 2.8-3.6 3.2-.3.4-.8.6-.5-.5l.2-.6c0-.3.1-.6-.1-.9-.3-.5-2.4-.8-3.6 0-1.5.8-2.6 3.3-2.8 2.3 0 0 0-.5-.2-.6-.1-.3-1-.5-1.7-.1-.8.4-1.2 1.4-1.5 1.8l-.2.4-.5 1-1.2 2.2c-.2.4-.1.8.1 1.1.2.3 1 .7 1.2.1l.4-.7.6-1.4.7-1.6c.3-.4 1-.7.8.2 0 .5-.3 1.4-.5 2 0 .4.6 1.1 1-.1a13 13 0 012.4-3.7c.4-.4 1.2-.6 1 .2-.2 1.5-.2 3.6.2 5.5.4 1.8 2 2.1 2.7-.5.5-1.5 1.8-4.4 2.9-6 .8-1.2 2.2-1.5 1.6-.2l-.8 2.4c-.3 1.4-.7 3.7-.1 5 .7 1.7 3.8 2.9 4.4 2.2.4-.4.4-1 0-1.2" />
+            </svg>
+            <span class="fs-5">Cookie Consent Manager</span>
+        </a>
+        <div>
+            <a class="btn btn-outline-primary me-2" href="https://github.com/lmc-eu/cookie-consent/#readme" target="_blank">Documentation</a>
+            <a class="btn btn-primary" href="https://github.com/lmc-eu/cookie-consent/releases" target="_blank">Download</a>
+        </div>
+    </div>
 </header>
 
-<div class="container mt-4">
-    <ul class="nav nav-tabs">
-        <li class="nav-item">
-            <a class="nav-link" href=".">Basic example</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link active" href="./configuration.html">Extended configuration</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link" href="./callbacks.html">Callbacks</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link" href="./theming.html">Theming</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link" href="https://github.com/lmc-eu/cookie-consent/" target="_blank">Documentation <i class="bi bi-box-arrow-up-right"></i></a>
-        </li>
-    </ul>
-</div>
+<main>
+    <div class="py-5 bg-light text-center">
+        <div class="container">
 
-<main class="container mt-4">
-    <div class="row">
-        <div class="col">
-            <p class="lead">
+            <h1 class="display-1 mt-md-3">Extended Configuration</h1>
+            <p class="lead mb-4 mb-md-5">
                 This is an example of extended configuration.
             </p>
 
-            <p>
-                <a href="" class="btn btn-warning" onclick="removeCookieAndReload();">
-                    Remove <code>lmc_ccm</code> cookie and reload
-                </a>
-            </p>
-            <p>
+            <ul class="nav nav-pills justify-content-center mb-3">
+                <li class="nav-item">
+                    <a class="nav-link" href=".">Basic example</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link active" href="./configuration.html">Extended configuration</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="./callbacks.html">Callbacks</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="./theming.html">Theming</a>
+                </li>
+            </ul>
 
-            <h3 class="mt-4">Use cookieConsent instance</h3>
+        </div>
+    </div>
+    <div id="reset" class="position-fixed bottom-0 end-0 me-5 mb-5" style="z-index: 1" hidden>
+        <a href="" class="btn btn-lg btn-warning shadow-lg" onclick="removeCookieAndReload();" data-bs-toggle="tooltip" data-bs-html="true" title="Remove <code>lmc_ccm</code> cookie and reload">
+            <i class="bi bi-arrow-clockwise"></i>
+            Reset cookie
+        </a>
+    </div>
+    <div class="container py-5">
+        <div class="row justify-content-lg-center">
+            <div class="col col-lg-10 col-xl-8">
 
-            <p>
-                When <a href="https://github.com/lmc-eu/cookie-consent-manager#callbacks">callbacks</a> does not satisfy
-                your needs to conditional code execution, you can also store cookieConsent instance in a variable
-                and access it later when needed – see source code.
-            </p>
+                <h2 class="mt-md-3 mb-3">Use cookieConsent instance</h2>
 
-            <p>
-                <a href="#" onclick="ccm.allowedCategory('analytics') ? console.log('Execute some analytics feature') : console.log('Do not execute analytics'); return false;">
-                    Example link with conditional logic activated <code>onclick</code></a>
-                (see browser console – note difference with and without accepted consent)
-            </p>
+                <p class="mb-4">
+                    When <a href="https://github.com/lmc-eu/cookie-consent-manager#callbacks">callbacks</a> does not satisfy
+                    your needs to conditional code execution, you can also store cookieConsent instance in a variable
+                    and access it later when needed – see source code.
+                </p>
+
+                <p>
+                    <a href="#" onclick="ccm.allowedCategory('analytics') ? console.log('Execute some analytics feature') : console.log('Do not execute analytics'); return false;">
+                        Example link with conditional logic activated <code>onclick</code></a>
+                    (see browser console – note difference with and without accepted consent)
+                </p>
+
+            </div>
         </div>
     </div>
 </main>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+<script>
+    // Bootstrap Tooltips
+    const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+    const tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+        return new bootstrap.Tooltip(tooltipTriggerEl)
+    })
+</script>
 
 <script defer src="../dist/init.js"></script>
 <script>
@@ -87,6 +113,7 @@
           delay: 500, // show cookie consent banner after 500ms
           page_scripts: false, // disable third-party script management, see https://github.com/lmc-eu/cookie-consent-manager#third-party-scripts-loaded-via-script
         },
+        onAccept: () => document.getElementById('reset').removeAttribute('hidden'), // reveal Reset cookie button
         onFirstAcceptOnlyNecessary: () => { // consent with only necessary cookies was just given by the user
           window.localStorage.clear(); // clear everything in localStorage if it is not used for any 'necessary' data
         },

--- a/examples/configuration.html
+++ b/examples/configuration.html
@@ -2,19 +2,21 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="preconnect" href="https://cdn.jsdelivr.net">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
     <title>Cookie Consent Manager – extended configuration example</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.0/font/bootstrap-icons.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap">
     <script src="./functions.js" defer></script>
 
-    <link rel="stylesheet" href="../dist/LmcCookieConsentManager.css">
+    <link rel="stylesheet" href="../dist/LmcCookieConsentManager.min.css"><!-- You will load this from CDN instead -->
 </head>
-<body>
+<body style="padding-bottom: 420px">
 
 <header class="container mt-4">
     <h1>LMC Cookie Consent Manager</h1>

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,6 +11,7 @@
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.0/font/bootstrap-icons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@v1.25/themes/prism.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap">
     <script src="./functions.js" defer></script>
 
@@ -19,83 +20,104 @@
     <!-- Following script will be loaded only after "personalization" consent is detected -->
     <script type="text/plain" data-cookiecategory="personalization" src="./personalization.js" defer></script>
 </head>
-<body style="padding-bottom: 420px">
+<body style="padding-bottom: 380px">
 
-<header class="container mt-4">
-    <h1>LMC Cookie Consent Manager</h1>
+<header class="container">
+    <div class="d-flex flex-column align-items-center flex-md-row py-3">
+        <a href="." class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-dark text-decoration-none">
+            <svg class="me-3" width="67" height="52" viewBox="0 0 67 52">
+                <path fill="#12bcca" d="M3.3 49.2c-1.8.3-5.4 2.1-1.6 2.7 3.9.7 44.4-3.6 63-1.5 2.9.4 2.3-.8-.6-1a472 472 0 00-60.8-.2" />
+                <path fill="#002d5c" d="M23 39.4c.7-.3 1.7.8 1 1.6a1.5 1.5 0 01-.4.2c-2.3.8-9.5 2.6-12.1-3.5-.9.9-1.7 1.4-2.6 2-6.3 4.5-6.4 2.5-6.4 2.4-.3-1.8 1.4-2 1.4-2s3.4-.7 6.8-4.1c-.7-3.3-1.6-10-.7-15.5C11.7 8.8 16 2.5 20.2.8c4.1-1.4 5.2 1.1 5.5 3.2 1 5-.3 15.3-12.5 31.8.6 2.1 1 3.6 2.7 4.6 3.4 2 6.8-.9 7.2-1m-10.3-5.2c1.8-2 7-10.3 8.3-13 4.2-9.5 3.9-17 2.2-18.2C18.8-.2 9.6 23.2 12.7 34.2M57.4 31.6c-3.4 5-8 6.5-8 6.5s-7 2.8-9 .1c-2.2-2.6.6-7 1.1-7.9.5-.7 2.6-2.8 2.6-1.4 0 1.2-.5 3.5 1 2.9.2-.2.7-.7 1-1.3.5-1 1-3-.8-4-2.8-1.7-5.7 1.7-6.5 4.3-.6 1.8-1.6 5.2.3 7.4 4.5 5 13.2 2.8 19.3-2 4.6-3.8 2.4-9.6-1-4.6" />
+                <path fill="#002d5c" d="M36.6 39.6a3 3 0 01-1.7-2.7c0-3.4 1.6-6.5 2-7.3.3-.8-1.3-2-3.1-1.5-1.9.4-3.3 2.8-3.6 3.2-.3.4-.8.6-.5-.5l.2-.6c0-.3.1-.6-.1-.9-.3-.5-2.4-.8-3.6 0-1.5.8-2.6 3.3-2.8 2.3 0 0 0-.5-.2-.6-.1-.3-1-.5-1.7-.1-.8.4-1.2 1.4-1.5 1.8l-.2.4-.5 1-1.2 2.2c-.2.4-.1.8.1 1.1.2.3 1 .7 1.2.1l.4-.7.6-1.4.7-1.6c.3-.4 1-.7.8.2 0 .5-.3 1.4-.5 2 0 .4.6 1.1 1-.1a13 13 0 012.4-3.7c.4-.4 1.2-.6 1 .2-.2 1.5-.2 3.6.2 5.5.4 1.8 2 2.1 2.7-.5.5-1.5 1.8-4.4 2.9-6 .8-1.2 2.2-1.5 1.6-.2l-.8 2.4c-.3 1.4-.7 3.7-.1 5 .7 1.7 3.8 2.9 4.4 2.2.4-.4.4-1 0-1.2" />
+            </svg>
+            <span class="fs-5">Cookie Consent Manager</span>
+        </a>
+        <div>
+            <a class="btn btn-outline-primary me-2" href="https://github.com/lmc-eu/cookie-consent/#readme" target="_blank">Documentation</a>
+            <a class="btn btn-primary" href="https://github.com/lmc-eu/cookie-consent/releases" target="_blank">Download</a>
+        </div>
+    </div>
 </header>
 
-<div class="container mt-4">
-    <ul class="nav nav-tabs">
-        <li class="nav-item">
-            <a class="nav-link active" href=".">Basic example</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link" href="./configuration.html">Extended configuration</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link" href="./callbacks.html">Callbacks</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link" href="./theming.html">Theming</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link" href="https://github.com/lmc-eu/cookie-consent/" target="_blank">Documentation <i class="bi bi-box-arrow-up-right"></i></a>
-        </li>
-    </ul>
-</div>
+<main>
+    <div class="py-5 bg-light text-center">
+        <div class="container">
 
-<main class="container mt-4">
-    <div class="row">
-        <div class="col">
-            <p class="lead">
+            <h1 class="display-1 mt-md-3">Basic Example</h1>
+            <p class="lead mb-4 mb-md-5">
                 This example shows some basic usage of the LMC Cookie Consent Manager.
             </p>
-            <p>
-                <a href="" class="btn btn-warning" onclick="removeCookieAndReload();">
-                    Remove <code>lmc_ccm</code> cookie and reload
-                </a>
-            </p>
 
-            <h3 class="mt-4">Cookie content</h3>
-            <p id="onaccept-content">
-                (empty)
-            </p>
+            <ul class="nav nav-pills justify-content-center mb-3">
+                <li class="nav-item">
+                    <a class="nav-link active" href=".">Basic example</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="./configuration.html">Extended configuration</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="./callbacks.html">Callbacks</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="./theming.html">Theming</a>
+                </li>
+            </ul>
 
-            <h3 class="mt-4">Content set from <code>onAcceptAll()</code> callback</h3>
-            <p id="onacceptall-content">
-                (empty)
-            </p>
 
-            <h3 class="mt-4">Content set by callback when <code>ad</code> consent detected</h3>
-            <p id="ad-content">
-                (empty)
-            </p>
+        </div>
+    </div>
+    <div id="reset" class="position-fixed bottom-0 end-0 me-5 mb-5" style="z-index: 1" hidden>
+        <a href="" class="btn btn-lg btn-warning shadow-lg" onclick="removeCookieAndReload();" data-bs-toggle="tooltip" data-bs-html="true" title="Remove <code>lmc_ccm</code> cookie and reload">
+            <i class="bi bi-arrow-clockwise"></i>
+            Reset cookie
+        </a>
+    </div>
+    <div class="container py-5">
+        <div class="row justify-content-lg-center">
+            <div class="col col-lg-10 col-xl-8">
 
-            <h3 class="mt-4">Content set by external script when <code>personalization</code> consent detected</h3>
-            <p id="personalization-content">
-                (empty)
-            </p>
+                <h2 class="mt-md-3 mb-3">Cookie content</h2>
+                <div id="onaccept-content">(empty)</div>
 
-            <h3 class="mt-4">Allowed consent categories</h3>
-            <div class="row">
-                <div class="col-md-6 col-xs-12">
+                <h2 class="mt-4 mt-md-5 mb-3">Content set from <code>onAcceptAll()</code> callback</h2>
+                <p id="onacceptall-content">
+                    (empty)
+                </p>
 
-                    <ul class="list-group">
-                        <li class="list-group-item" id="consent-necessary">necessary</li>
-                        <li class="list-group-item" id="consent-ad">ad</li>
-                        <li class="list-group-item" id="consent-analytics">analytics</li>
-                        <li class="list-group-item" id="consent-functionality">functionality</li>
-                        <li class="list-group-item" id="consent-personalization">personalization</li>
-                    </ul>
-                </div>
+                <h2 class="mt-4 mt-md-5 mb-3">Content set by callback when <code>ad</code> consent detected</h2>
+                <p id="ad-content">
+                    (empty)
+                </p>
+
+                <h2 class="mt-4 mt-md-5 mb-3">Content set by external script when <code>personalization</code> consent detected</h2>
+                <p id="personalization-content">
+                    (empty)
+                </p>
+
+                <h2 class="mt-4 mt-md-5 mb-3">Allowed consent categories</h2>
+                <ul class="list-group">
+                    <li class="list-group-item" id="consent-necessary">necessary</li>
+                    <li class="list-group-item" id="consent-ad">ad</li>
+                    <li class="list-group-item" id="consent-analytics">analytics</li>
+                    <li class="list-group-item" id="consent-functionality">functionality</li>
+                    <li class="list-group-item" id="consent-personalization">personalization</li>
+                </ul>
+
             </div>
-
-            <!-- Spacer to make content scrollable -->
-            <div style="height: 300px;"></div>
         </div>
     </div>
 </main>
+
+<script src="https://cdn.jsdelivr.net/npm/prismjs@v1.25/components/prism-core.min.js" data-manual></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@v1.25/plugins/autoloader/prism-autoloader.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+<script>
+    // Bootstrap Tooltips
+    const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+    const tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+        return new bootstrap.Tooltip(tooltipTriggerEl)
+    })
+</script>
 
 <script defer src="../dist/init.js"></script><!-- You will load this from CDN instead -->
 <script>
@@ -105,11 +127,13 @@
       {
         consentCollectorApiUrl: 'https://ccm.lmc.cz/local-data-acceptation-data-entries?Spot=(public,demo)', // override default URL for demo purposes; do not set custom consentCollectorApiUrl unless you have been explicitly guided to do so!
         onAccept: (cookie, cookieConsent) => { // any type of consent (including "only necessary") detected
-          document.getElementById('onaccept-content').innerHTML = JSON.stringify(cookie)
+          document.getElementById('onaccept-content').innerHTML = `<pre><code class="language-json">${JSON.stringify(cookie)}</code></pre>`;
+          window.Prism.highlightAll(); // highlight previous piece of code with Prism.js
+          document.getElementById('reset').removeAttribute('hidden'); // reveal Reset cookie button
 
           for (const category of ['necessary', 'ad', 'analytics', 'functionality', 'personalization']) {
             if (cookieConsent.allowedCategory(category)) {
-              markConsentCategoryAllowed(category)
+              markConsentCategoryAllowed(category);
             }
           }
         },

--- a/examples/index.html
+++ b/examples/index.html
@@ -2,13 +2,15 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="preconnect" href="https://cdn.jsdelivr.net">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
     <title>Cookie Consent Manager – example</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.0/font/bootstrap-icons.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap">
     <script src="./functions.js" defer></script>
 
@@ -17,7 +19,7 @@
     <!-- Following script will be loaded only after "personalization" consent is detected -->
     <script type="text/plain" data-cookiecategory="personalization" src="./personalization.js" defer></script>
 </head>
-<body>
+<body style="padding-bottom: 420px">
 
 <header class="container mt-4">
     <h1>LMC Cookie Consent Manager</h1>

--- a/examples/theming.html
+++ b/examples/theming.html
@@ -2,19 +2,62 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="preconnect" href="https://cdn.jsdelivr.net">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
     <title>Cookie Consent Manager – theming example</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.0/font/bootstrap-icons.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@v1.25/themes/prism.css">
+    <!-- For the purpose of this demo, we are loading two typefaces: -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Noto+Sans:wght@400;700&display=swap">
     <script src="./functions.js" defer></script>
 
-    <link rel="stylesheet" href="../dist/LmcCookieConsentManager.css">
+    <link rel="stylesheet" href="../dist/LmcCookieConsentManager.min.css"><!-- You will load this from CDN instead -->
+
+    <style type="text/css">
+        .custom-theme {
+            --lmcccm-font-family: 'Noto Sans', 'Roboto', 'Open Sans', system-ui, sans-serif;
+            --lmcccm-base-font-size: 14px;
+            --lmcccm-bg: rgb(242, 203, 5);
+            --lmcccm-text: rgb(72, 72, 72);
+            --lmcccm-link-text: var(--lmcccm-text);
+            --lmcccm-link-hover-text: rgb(17, 17, 17);
+            --lmcccm-link-active-text: var(--lmcccm-link-hover-text);
+            --lmcccm-btn-border-radius: 1.25em;
+            --lmcccm-btn-primary-bg: rgb(17, 17, 17);
+            --lmcccm-btn-primary-text: rgb(255, 255, 255);
+            --lmcccm-btn-primary-hover-bg: rgb(51, 51, 51);
+            --lmcccm-btn-primary-hover-text: var(--lmcccm-btn-primary-text);
+            --lmcccm-btn-primary-active-bg: rgb(0, 0, 0);
+            --lmcccm-btn-primary-active-text: var(--lmcccm-btn-primary-text);
+            --lmcccm-btn-secondary-text: var(--lmcccm-link-text);
+            --lmcccm-btn-secondary-hover-text: var(--lmcccm-link-hover-text);
+            --lmcccm-btn-secondary-active-text: var(--lmcccm-link-active-text);
+        }
+
+        .custom-theme .c_darkmode {
+            --lmcccm-bg: rgb(17, 17, 17);
+            --lmcccm-text: rgb(255, 255, 255);
+            --lmcccm-link-text: var(--lmcccm-text);
+            --lmcccm-link-hover-text: rgb(245, 245, 245);
+            --lmcccm-link-active-text: var(--lmcccm-link-hover-text);
+            --lmcccm-btn-primary-bg: rgb(255, 255, 255);
+            --lmcccm-btn-primary-text: rgb(17, 17, 17);
+            --lmcccm-btn-primary-hover-bg: rgb(245, 245, 245);
+            --lmcccm-btn-primary-hover-text: var(--lmcccm-btn-primary-text);
+            --lmcccm-btn-primary-active-bg: rgb(255, 255, 255);
+            --lmcccm-btn-primary-active-text: var(--lmcccm-btn-primary-text);
+            --lmcccm-btn-secondary-text: var(--lmcccm-link-text);
+            --lmcccm-btn-secondary-hover-text: var(--lmcccm-link-hover-text);
+            --lmcccm-btn-secondary-active-text: var(--lmcccm-link-active-text);
+        }
+    </style>
 </head>
-<body>
+<body style="padding-bottom: 420px">
 
 <header class="container mt-4">
     <h1>LMC Cookie Consent Manager</h1>
@@ -52,18 +95,69 @@
                     Remove <code>lmc_ccm</code> cookie and reload
                 </a>
             </p>
+
+            <h3 class="mt-4">With Spirit Design System</h3>
             <p>
-                <button type="button" class="btn btn-dark" onclick="document.body.classList.toggle('c_darkmode')">
+                If your project uses <a href="https://github.com/lmc-eu/spirit-design-system">Spirit Design System</a>,
+                theming is done automatically. Just follow the steps in <a href="https://github.com/lmc-eu/cookie-consent-manager#with-spirit-design-system">README</a>
+                to compile Cookie Consent Manager styles with Spirit and you are done.
+            </p>
+
+            <h3 class="mt-4">Without Spirit Design System</h3>
+            <p>
+                If your project does not use <a href="https://github.com/lmc-eu/spirit-design-system">Spirit Design System</a>,
+                you can still manually customize the appearance of the Cookie Consent Manager UI.
+                Head over to <a href="https://github.com/lmc-eu/cookie-consent-manager#without-spirit-design-system">README</a>
+                to get the full list of available CSS custom properties.
+            </p>
+            <details class="mb-4">
+                <summary class="link-primary">Example theme:</summary>
+                <pre class="mt-4"><code class="language-css">:root {
+    --lmcccm-font-family: 'Noto Sans', 'Roboto', 'Open Sans', system-ui, sans-serif;
+    --lmcccm-base-font-size: 14px;
+    --lmcccm-bg: rgb(242, 203, 5);
+    --lmcccm-text: rgb(72, 72, 72);
+    --lmcccm-link-text: var(--lmcccm-text);
+    --lmcccm-link-hover-text: rgb(17, 17, 17);
+    --lmcccm-link-active-text: var(--lmcccm-link-hover-text);
+    --lmcccm-btn-border-radius: 1.25em;
+    --lmcccm-btn-primary-bg: rgb(17, 17, 17);
+    --lmcccm-btn-primary-text: rgb(255, 255, 255);
+    --lmcccm-btn-primary-hover-bg: rgb(51, 51, 51);
+    --lmcccm-btn-primary-hover-text: var(--lmcccm-btn-primary-text);
+    --lmcccm-btn-primary-active-bg: rgb(0, 0, 0);
+    --lmcccm-btn-primary-active-text: var(--lmcccm-btn-primary-text);
+    --lmcccm-btn-secondary-text: var(--lmcccm-link-text);
+    --lmcccm-btn-secondary-hover-text: var(--lmcccm-link-hover-text);
+    --lmcccm-btn-secondary-active-text: var(--lmcccm-link-active-text);
+}</code></pre>
+            </details>
+            <p>
+                <button type="button" class="btn btn-outline-primary" onclick="document.documentElement.classList.toggle('custom-theme')">
+                    Toggle custom theme
+                </button>
+            </p>
+
+            <h3 class="mt-4">Dark Mode</h3>
+            <p>
+                Default dark mode of Cookie Consent Manager is rather a dark version than a real dark mode
+                which is not yet supported by Spirit (if it was, it would apply less contrasting colors).
+                But it's available for you to have more design choices to choose from. You can
+                <a href="https://github.com/lmc-eu/cookie-consent-manager#dark-mode">customize</a>
+                dark mode colors the same way as the default light color scheme.
+            </p>
+            <p>
+                <button type="button" class="btn btn-outline-dark" onclick="document.body.classList.toggle('c_darkmode')">
                     Toggle dark mode
                 </button>
             </p>
 
-
-            <h3 class="mt-4">TODO</h3>
-
         </div>
     </div>
 </main>
+
+<script src="https://cdn.jsdelivr.net/npm/prismjs@v1.25/components/prism-core.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@v1.25/plugins/autoloader/prism-autoloader.min.js"></script>
 
 <script defer src="../dist/init.js"></script>
 <script>

--- a/examples/theming.html
+++ b/examples/theming.html
@@ -55,64 +55,92 @@
             --lmcccm-btn-secondary-hover-text: var(--lmcccm-link-hover-text);
             --lmcccm-btn-secondary-active-text: var(--lmcccm-link-active-text);
         }
+
+        #darkmode-icon-moon {
+            display: none;
+        }
+
+        .c_darkmode #darkmode-icon-moon {
+            display: inline;
+        }
+
+        .c_darkmode #darkmode-icon-sun {
+            display: none;
+        }
     </style>
 </head>
-<body style="padding-bottom: 420px">
+<body style="padding-bottom: 380px">
 
-<header class="container mt-4">
-    <h1>LMC Cookie Consent Manager</h1>
+<header class="container">
+    <div class="d-flex flex-column align-items-center flex-md-row py-3">
+        <a href="." class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-dark text-decoration-none">
+            <svg class="me-3" width="67" height="52" viewBox="0 0 67 52">
+                <path fill="#12bcca" d="M3.3 49.2c-1.8.3-5.4 2.1-1.6 2.7 3.9.7 44.4-3.6 63-1.5 2.9.4 2.3-.8-.6-1a472 472 0 00-60.8-.2" />
+                <path fill="#002d5c" d="M23 39.4c.7-.3 1.7.8 1 1.6a1.5 1.5 0 01-.4.2c-2.3.8-9.5 2.6-12.1-3.5-.9.9-1.7 1.4-2.6 2-6.3 4.5-6.4 2.5-6.4 2.4-.3-1.8 1.4-2 1.4-2s3.4-.7 6.8-4.1c-.7-3.3-1.6-10-.7-15.5C11.7 8.8 16 2.5 20.2.8c4.1-1.4 5.2 1.1 5.5 3.2 1 5-.3 15.3-12.5 31.8.6 2.1 1 3.6 2.7 4.6 3.4 2 6.8-.9 7.2-1m-10.3-5.2c1.8-2 7-10.3 8.3-13 4.2-9.5 3.9-17 2.2-18.2C18.8-.2 9.6 23.2 12.7 34.2M57.4 31.6c-3.4 5-8 6.5-8 6.5s-7 2.8-9 .1c-2.2-2.6.6-7 1.1-7.9.5-.7 2.6-2.8 2.6-1.4 0 1.2-.5 3.5 1 2.9.2-.2.7-.7 1-1.3.5-1 1-3-.8-4-2.8-1.7-5.7 1.7-6.5 4.3-.6 1.8-1.6 5.2.3 7.4 4.5 5 13.2 2.8 19.3-2 4.6-3.8 2.4-9.6-1-4.6" />
+                <path fill="#002d5c" d="M36.6 39.6a3 3 0 01-1.7-2.7c0-3.4 1.6-6.5 2-7.3.3-.8-1.3-2-3.1-1.5-1.9.4-3.3 2.8-3.6 3.2-.3.4-.8.6-.5-.5l.2-.6c0-.3.1-.6-.1-.9-.3-.5-2.4-.8-3.6 0-1.5.8-2.6 3.3-2.8 2.3 0 0 0-.5-.2-.6-.1-.3-1-.5-1.7-.1-.8.4-1.2 1.4-1.5 1.8l-.2.4-.5 1-1.2 2.2c-.2.4-.1.8.1 1.1.2.3 1 .7 1.2.1l.4-.7.6-1.4.7-1.6c.3-.4 1-.7.8.2 0 .5-.3 1.4-.5 2 0 .4.6 1.1 1-.1a13 13 0 012.4-3.7c.4-.4 1.2-.6 1 .2-.2 1.5-.2 3.6.2 5.5.4 1.8 2 2.1 2.7-.5.5-1.5 1.8-4.4 2.9-6 .8-1.2 2.2-1.5 1.6-.2l-.8 2.4c-.3 1.4-.7 3.7-.1 5 .7 1.7 3.8 2.9 4.4 2.2.4-.4.4-1 0-1.2" />
+            </svg>
+            <span class="fs-5">Cookie Consent Manager</span>
+        </a>
+        <div>
+            <a class="btn btn-outline-primary me-2" href="https://github.com/lmc-eu/cookie-consent/#readme" target="_blank">Documentation</a>
+            <a class="btn btn-primary" href="https://github.com/lmc-eu/cookie-consent/releases" target="_blank">Download</a>
+        </div>
+    </div>
 </header>
 
-<div class="container mt-4">
-    <ul class="nav nav-tabs">
-        <li class="nav-item">
-            <a class="nav-link" href=".">Basic example</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link" href="./configuration.html">Extended configuration</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link" href="./callbacks.html">Callbacks</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link active" href="./theming.html">Theming</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link" href="https://github.com/lmc-eu/cookie-consent/" target="_blank">Documentation <i class="bi bi-box-arrow-up-right"></i></a>
-        </li>
-    </ul>
-</div>
+<main>
+    <div class="py-5 bg-light text-center">
+        <div class="container">
 
-<main class="container mt-4">
-    <div class="row">
-        <div class="col">
-            <p class="lead">
+            <h1 class="display-1 mt-md-3">Theming</h1>
+            <p class="lead mb-4 mb-md-5">
                 This is an example of design theming.
             </p>
 
-            <p>
-                <a href="" class="btn btn-warning" onclick="removeCookieAndReload();">
-                    Remove <code>lmc_ccm</code> cookie and reload
-                </a>
-            </p>
+            <ul class="nav nav-pills justify-content-center mb-3">
+                <li class="nav-item">
+                    <a class="nav-link" href=".">Basic example</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="./configuration.html">Extended configuration</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="./callbacks.html">Callbacks</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link active" href="./theming.html">Theming</a>
+                </li>
+            </ul>
 
-            <h3 class="mt-4">With Spirit Design System</h3>
-            <p>
-                If your project uses <a href="https://github.com/lmc-eu/spirit-design-system">Spirit Design System</a>,
-                theming is done automatically. Just follow the steps in <a href="https://github.com/lmc-eu/cookie-consent-manager#with-spirit-design-system">README</a>
-                to compile Cookie Consent Manager styles with Spirit and you are done.
-            </p>
+        </div>
+    </div>
+    <div id="reset" class="position-fixed bottom-0 end-0 me-5 mb-5" style="z-index: 1" hidden>
+        <a href="" class="btn btn-lg btn-warning shadow-lg" onclick="removeCookieAndReload();" data-bs-toggle="tooltip" data-bs-html="true" title="Remove <code>lmc_ccm</code> cookie and reload">
+            <i class="bi bi-arrow-clockwise"></i>
+            Reset cookie
+        </a>
+    </div>
+    <div class="container py-5">
+        <div class="row justify-content-lg-center">
+            <div class="col col-lg-10 col-xl-8">
 
-            <h3 class="mt-4">Without Spirit Design System</h3>
-            <p>
-                If your project does not use <a href="https://github.com/lmc-eu/spirit-design-system">Spirit Design System</a>,
-                you can still manually customize the appearance of the Cookie Consent Manager UI.
-                Head over to <a href="https://github.com/lmc-eu/cookie-consent-manager#without-spirit-design-system">README</a>
-                to get the full list of available CSS custom properties.
-            </p>
-            <details class="mb-4">
-                <summary class="link-primary">Example theme:</summary>
-                <pre class="mt-4"><code class="language-css">:root {
+                <h2 class="mt-md-3 mb-3">With Spirit Design System</h2>
+                <p>
+                    If your project uses <a href="https://github.com/lmc-eu/spirit-design-system">Spirit Design System</a>,
+                    theming is done automatically. Just follow the steps in <a href="https://github.com/lmc-eu/cookie-consent-manager#with-spirit-design-system">README</a>
+                    to compile Cookie Consent Manager styles with Spirit and you are done.
+                </p>
+
+                <h2 class="mt-4 mt-md-5 mb-3">Without Spirit Design System</h2>
+                <p class="mb-4">
+                    If your project does not use <a href="https://github.com/lmc-eu/spirit-design-system">Spirit Design System</a>,
+                    you can still manually customize the appearance of the Cookie Consent Manager UI.
+                    Head over to <a href="https://github.com/lmc-eu/cookie-consent-manager#without-spirit-design-system">README</a>
+                    to get the full list of available CSS custom properties.
+                </p>
+                <details class="mb-4">
+                    <summary class="link-primary">Example theme:</summary>
+                    <pre class="mt-4"><code class="language-css">:root {
     --lmcccm-font-family: 'Noto Sans', 'Roboto', 'Open Sans', system-ui, sans-serif;
     --lmcccm-base-font-size: 14px;
     --lmcccm-bg: rgb(242, 203, 5);
@@ -131,33 +159,45 @@
     --lmcccm-btn-secondary-hover-text: var(--lmcccm-link-hover-text);
     --lmcccm-btn-secondary-active-text: var(--lmcccm-link-active-text);
 }</code></pre>
-            </details>
-            <p>
-                <button type="button" class="btn btn-outline-primary" onclick="document.documentElement.classList.toggle('custom-theme')">
-                    Toggle custom theme
-                </button>
-            </p>
+                </details>
+                <p>
+                    <button type="button" class="btn btn-outline-primary" onclick="document.documentElement.classList.toggle('custom-theme')">
+                        <i class="bi bi-palette"></i>
+                        Toggle custom theme
+                    </button>
+                </p>
 
-            <h3 class="mt-4">Dark Mode</h3>
-            <p>
-                Default dark mode of Cookie Consent Manager is rather a dark version than a real dark mode
-                which is not yet supported by Spirit (if it was, it would apply less contrasting colors).
-                But it's available for you to have more design choices to choose from. You can
-                <a href="https://github.com/lmc-eu/cookie-consent-manager#dark-mode">customize</a>
-                dark mode colors the same way as the default light color scheme.
-            </p>
-            <p>
-                <button type="button" class="btn btn-outline-dark" onclick="document.body.classList.toggle('c_darkmode')">
-                    Toggle dark mode
-                </button>
-            </p>
+                <h2 class="mt-4 mt-md-5 mb-3">Dark Mode</h2>
+                <p class="mb-4">
+                    Default dark mode of Cookie Consent Manager is rather a dark version than a real dark mode
+                    which is not yet supported by Spirit (if it was, it would apply less contrasting colors).
+                    But it's available for you to have more design choices to choose from. You can
+                    <a href="https://github.com/lmc-eu/cookie-consent-manager#dark-mode">customize</a>
+                    dark mode colors the same way as the default light color scheme.
+                </p>
+                <p>
+                    <button type="button" class="btn btn-outline-dark" onclick="document.body.classList.toggle('c_darkmode')">
+                        <i id="darkmode-icon-moon" class="bi bi-moon"></i>
+                        <i id="darkmode-icon-sun" class="bi bi-sun"></i>
+                        Toggle dark mode
+                    </button>
+                </p>
 
+            </div>
         </div>
     </div>
 </main>
 
 <script src="https://cdn.jsdelivr.net/npm/prismjs@v1.25/components/prism-core.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/prismjs@v1.25/plugins/autoloader/prism-autoloader.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+<script>
+    // Bootstrap Tooltips
+    const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+    const tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+        return new bootstrap.Tooltip(tooltipTriggerEl)
+    })
+</script>
 
 <script defer src="../dist/init.js"></script>
 <script>
@@ -166,6 +206,7 @@
       'github.example',
       {
         consentCollectorApiUrl: 'https://ccm.lmc.cz/local-data-acceptation-data-entries?Spot=(public,demo)', // override default URL for demo purposes; do not set custom consentCollectorApiUrl unless you have been explicitly guided to do so!
+        onAccept: () => document.getElementById('reset').removeAttribute('hidden'), // reveal Reset cookie button
       }
     );
   });

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "replace-version": "node scripts/readme-replace-version.js"
   },
   "dependencies": {
-    "@lmc-eu/spirit-design-tokens": "^0.4.0",
+    "@lmc-eu/spirit-design-tokens": "^0.4.4",
     "nanoid": "^3.1.30",
     "vanilla-cookieconsent": "^2.7.0-rc3"
   },

--- a/src/scss/_cc-theme.scss
+++ b/src/scss/_cc-theme.scss
@@ -10,7 +10,7 @@
     --cc-btn-primary-bg: var(--lmcccm-p-btn-primary-bg);
     --cc-btn-primary-text: var(--lmcccm-p-btn-primary-text);
     --cc-btn-primary-hover-bg: var(--lmcccm-p-btn-primary-hover-bg);
-    --cc-btn-secondary-bg: var(--lmcccm-p-btn-secondary-bg);
+    --cc-btn-secondary-bg: transparent;
     --cc-btn-secondary-text: var(--lmcccm-p-btn-secondary-text);
     --cc-btn-secondary-hover-bg: var(--lmcccm-p-btn-secondary-hover-bg);
     //--cc-toggle-bg-off: #919ea6;

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -158,18 +158,22 @@
 
 .cc_div .c-bn {
     padding: tools.rem2em(tokens.$space-4) tools.rem2em(tokens.$space-7);
-    border-radius: tools.rem2em(tokens.$radius-1);
+    border-radius: var(--lmcccm-p-btn-border-radius);
 }
 
 #c-bns button:first-child,
 #s-bns button:first-child {
+    border: var(--lmcccm-p-btn-border-width) var(--lmcccm-p-btn-border-style) var(--lmcccm-p-btn-primary-border);
+
     &:hover {
         color: var(--lmcccm-p-btn-primary-hover-text);
+        border-color: var(--lmcccm-p-btn-primary-hover-border);
     }
 
     &:active {
         color: var(--lmcccm-p-btn-primary-active-text);
         background: var(--lmcccm-p-btn-primary-active-bg);
+        border-color: var(--lmcccm-p-btn-primary-active-border);
     }
 }
 

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -185,10 +185,6 @@
     font-weight: inherit;
     font-size: inherit;
     text-decoration: underline;
-
-    &:active {
-        background: var(--lmcccm-p-btn-secondary-active-bg);
-    }
 }
 
 @media screen and (max-width: settings.$breakpoint-tablet-down) {

--- a/src/scss/_theme.scss
+++ b/src/scss/_theme.scss
@@ -8,6 +8,7 @@
 // By using Spirit design tokens, all Spirit-based projects benefit from plug-and-play setup.
 
 @use '@tokens' as tokens;
+@use 'tools';
 
 // Stylelint and Prettier are clashing on long lines. Let's prefer Stylelint.
 /* prettier-ignore */
@@ -17,7 +18,7 @@
     // Typography
     // ==========
 
-    --lmcccm-p-base-font-size: var(--lmcccm-base-font-size, #{tokens.$font-size-base});
+    --lmcccm-p-base-font-size: var(--lmcccm-base-font-size, #{tools.rem2em(tokens.$font-size-base)});
     --lmcccm-p-font-family: var(--lmcccm-font-family, #{tokens.$font-family-default});
 
     //

--- a/src/scss/_theme.scss
+++ b/src/scss/_theme.scss
@@ -7,6 +7,7 @@
 //
 // By using Spirit design tokens, all Spirit-based projects benefit from plug-and-play setup.
 
+@use 'sass:list';
 @use '@tokens' as tokens;
 @use 'tools';
 
@@ -15,11 +16,14 @@
 
 :root {
     //
-    // Typography
-    // ==========
+    // Common Settings
+    // ===============
 
     --lmcccm-p-font-family: var(--lmcccm-font-family, #{tokens.$font-family-default});
     --lmcccm-p-base-font-size: var(--lmcccm-base-font-size, #{tools.rem2em(tokens.$font-size-base)});
+    --lmcccm-p-btn-border-width: var(--lmcccm-btn-border-width, #{list.nth(tokens.$border-1, 1)});
+    --lmcccm-p-btn-border-style: var(--lmcccm-btn-border-style, none); // TODO change to `#{list.nth(tokens.$border-1, 2)}` once Spirit tokens are updated.
+    --lmcccm-p-btn-border-radius: var(--lmcccm-btn-border-radius, #{tools.rem2em(tokens.$radius-1)});
 
     //
     // Light Mode
@@ -30,10 +34,13 @@
     --lmcccm-p-link-text: var(--lmcccm-link-text, #{tokens.$action-secondary-default});
     --lmcccm-p-link-hover-text: var(--lmcccm-link-hover-text, #{tokens.$action-secondary-hover});
     --lmcccm-p-link-active-text: var(--lmcccm-link-active-text, #{tokens.$action-secondary-active});
+    --lmcccm-p-btn-primary-border: var(--lmcccm-btn-primary-border, #{tokens.$action-primary-default});
     --lmcccm-p-btn-primary-bg: var(--lmcccm-btn-primary-bg, #{tokens.$action-primary-default});
     --lmcccm-p-btn-primary-text: var(--lmcccm-btn-primary-text, #{tokens.$text-primary-inverted-default});
+    --lmcccm-p-btn-primary-hover-border: var(--lmcccm-btn-primary-hover-border, #{tokens.$action-primary-hover});
     --lmcccm-p-btn-primary-hover-bg: var(--lmcccm-btn-primary-hover-bg, #{tokens.$action-primary-hover});
     --lmcccm-p-btn-primary-hover-text: var(--lmcccm-btn-primary-hover-text, #{tokens.$text-primary-inverted-default});
+    --lmcccm-p-btn-primary-active-border: var(--lmcccm-btn-primary-active-border, #{tokens.$action-primary-active});
     --lmcccm-p-btn-primary-active-bg: var(--lmcccm-btn-primary-active-bg, #{tokens.$action-primary-active});
     --lmcccm-p-btn-primary-active-text: var(--lmcccm-btn-primary-active-text, #{tokens.$text-primary-inverted-default});
     --lmcccm-p-btn-secondary-text: var(--lmcccm-btn-secondary-text, #{tokens.$action-link-primary-default});
@@ -54,10 +61,13 @@
     --lmcccm-p-link-text: var(--lmcccm-link-text, #{tokens.$text-secondary-inverted-default});
     --lmcccm-p-link-hover-text: var(--lmcccm-link-hover-text, #{tokens.$text-secondary-inverted-default});
     --lmcccm-p-link-active-text: var(--lmcccm-link-active-text, #{tokens.$text-secondary-inverted-default});
+    --lmcccm-p-btn-primary-border: var(--lmcccm-btn-primary-border, #{tokens.$action-primary-default});
     --lmcccm-p-btn-primary-bg: var(--lmcccm-btn-primary-bg, #{tokens.$action-primary-default});
     --lmcccm-p-btn-primary-text: var(--lmcccm-btn-primary-text, #{tokens.$text-primary-inverted-default});
+    --lmcccm-p-btn-primary-hover-border: var(--lmcccm-btn-primary-hover-border, #{tokens.$action-primary-hover});
     --lmcccm-p-btn-primary-hover-bg: var(--lmcccm-btn-primary-hover-bg, #{tokens.$action-primary-hover});
     --lmcccm-p-btn-primary-hover-text: var(--lmcccm-btn-primary-hover-text, #{tokens.$text-primary-inverted-default});
+    --lmcccm-p-btn-primary-active-border: var(--lmcccm-btn-primary-active-border, #{tokens.$action-primary-active});
     --lmcccm-p-btn-primary-active-bg: var(--lmcccm-btn-primary-active-bg, #{tokens.$action-primary-active});
     --lmcccm-p-btn-primary-active-text: var(--lmcccm-btn-primary-active-text, #{tokens.$text-primary-inverted-default});
     --lmcccm-p-btn-secondary-text: var(--lmcccm-btn-secondary-text, #{tokens.$text-secondary-inverted-default});

--- a/src/scss/_theme.scss
+++ b/src/scss/_theme.scss
@@ -18,7 +18,7 @@
     // ==========
 
     --lmcccm-p-base-font-size: var(--lmcccm-base-font-size, #{tokens.$font-size-base});
-    --lmcccm-p-font-family: var(--lmcccm-font-family, #{tokens.$font-family-default}), inherit;
+    --lmcccm-p-font-family: var(--lmcccm-font-family, #{tokens.$font-family-default});
 
     //
     // Light Mode

--- a/src/scss/_theme.scss
+++ b/src/scss/_theme.scss
@@ -18,8 +18,8 @@
     // Typography
     // ==========
 
-    --lmcccm-p-base-font-size: var(--lmcccm-base-font-size, #{tools.rem2em(tokens.$font-size-base)});
     --lmcccm-p-font-family: var(--lmcccm-font-family, #{tokens.$font-family-default});
+    --lmcccm-p-base-font-size: var(--lmcccm-base-font-size, #{tools.rem2em(tokens.$font-size-base)});
 
     //
     // Light Mode
@@ -36,11 +36,8 @@
     --lmcccm-p-btn-primary-hover-text: var(--lmcccm-btn-primary-hover-text, #{tokens.$text-primary-inverted-default});
     --lmcccm-p-btn-primary-active-bg: var(--lmcccm-btn-primary-active-bg, #{tokens.$action-primary-active});
     --lmcccm-p-btn-primary-active-text: var(--lmcccm-btn-primary-active-text, #{tokens.$text-primary-inverted-default});
-    --lmcccm-p-btn-secondary-bg: var(--lmcccm-btn-secondary-bg, transparent);
     --lmcccm-p-btn-secondary-text: var(--lmcccm-btn-secondary-text, #{tokens.$action-link-primary-default});
-    --lmcccm-p-btn-secondary-hover-bg: var(--lmcccm-btn-secondary-hover-bg, transparent);
     --lmcccm-p-btn-secondary-hover-text: var(--lmcccm-btn-secondary-hover-text, #{tokens.$action-link-primary-hover});
-    --lmcccm-p-btn-secondary-active-bg: var(--lmcccm-btn-secondary-active-bg, transparent);
     --lmcccm-p-btn-secondary-active-text: var(--lmcccm-btn-secondary-active-text, #{tokens.$action-link-primary-active});
 }
 
@@ -63,10 +60,7 @@
     --lmcccm-p-btn-primary-hover-text: var(--lmcccm-btn-primary-hover-text, #{tokens.$text-primary-inverted-default});
     --lmcccm-p-btn-primary-active-bg: var(--lmcccm-btn-primary-active-bg, #{tokens.$action-primary-active});
     --lmcccm-p-btn-primary-active-text: var(--lmcccm-btn-primary-active-text, #{tokens.$text-primary-inverted-default});
-    --lmcccm-p-btn-secondary-bg: var(--lmcccm-btn-secondary-bg, transparent);
     --lmcccm-p-btn-secondary-text: var(--lmcccm-btn-secondary-text, #{tokens.$text-secondary-inverted-default});
-    --lmcccm-p-btn-secondary-hover-bg: var(--lmcccm-btn-secondary-hover-bg, transparent);
     --lmcccm-p-btn-secondary-hover-text: var(--lmcccm-btn-secondary-hover-text, #{tokens.$text-secondary-inverted-default});
-    --lmcccm-p-btn-secondary-active-bg: var(--lmcccm-btn-secondary-active-bg, transparent);
     --lmcccm-p-btn-secondary-active-text: var(--lmcccm-btn-secondary-active-text, #{tokens.$text-secondary-inverted-default});
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1334,10 +1334,10 @@
   resolved "https://registry.yarnpkg.com/@lmc-eu/prettier-config/-/prettier-config-1.2.0.tgz#b72b292bd8797ac975ef363840592ca9b79f7772"
   integrity sha512-KLx4OyBSO3Gs7U47D6zr//cNs2tM0rgJxyRPPvbSDdSM4YTCbzR6Yo6fEhFPZ7wxcskSWrOJKFwNnAxwK3jHVg==
 
-"@lmc-eu/spirit-design-tokens@^0.4.0":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@lmc-eu/spirit-design-tokens/-/spirit-design-tokens-0.4.2.tgz#126747022be42001367c1f95ec0346e6a9cc9355"
-  integrity sha512-TBjBNnoWKJRMnlCHLXk2uRLodpb16L3uZFy2+fRT9Eh2LyUoU42O0FoIvN1AlA4RJCxYN7652m9moHEvadmXNQ==
+"@lmc-eu/spirit-design-tokens@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@lmc-eu/spirit-design-tokens/-/spirit-design-tokens-0.4.4.tgz#d0a26a1ecaa612f773977c20e77e9f4e0f198852"
+  integrity sha512-9/ymrInE340YIB67aY2tH11dxUP0g5TY5QxSQghiXldkveo6pia+TqvYsbEtoSIpxmU2b4Jn7WpmTFAAxL5VVw==
 
 "@lmc-eu/stylelint-config@^2.0.0":
   version "2.0.1"


### PR DESCRIPTION
- Fix: Revert font family inheritance as it blocked font customization
- Feat: Let base font size be inherited from surrounding text
- Docs: Make clear that Inter font link is mandatory unless font family is customized
- Deps: Update Spirit Design Tokens

As a result:

- Font size should work normally even on sites that use 10px hack for easier calculations.
- Cookie consent UI is rendered with a sans-serif font until Inter web font is loaded.
- We make it clear that Inter font is mandatory unless font family is customized (either via Spirit or custom properties).