### PR TITLE
Docs: Add table of contents to readme, grammar fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,14 +225,14 @@ initLmcCookieConsentManager( // when loaded as a module, these options are passe
 
 ## Configuration options
 
-| Option          | Type        | Default value                   | Description                                                                                                                               |
-|-----------------|-------------|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| `autodetectLang`| boolean     | true                            | Autodetect language based on the value of `<html lang="...">`. If autodetect fails or if unsupported language is detected, fallback to `defaultLang`.<br>When disabled, force language to `defaultLang`. |
-| `defaultLang`   | string      | 'cs'                            | Default language. One of `cs`, `de`, `en`, `hu`, `pl`, `ru`, `sk`, `uk`. This language will be used when autodetect is disabled or when it fails. |
-| `companyNames`  | array       | ['LMC']                         | Array of strings with company names. Adjust only when the consent needs to be given to multiple companies. [See example][examples-configuration]. |
-| `consentCollectorApiUrl`| ?string | 'https://ccm.lmc.cz/(...)'  | URL of the API where user consent information is sent. Null to disable sending data to the API. |
-| `config`        | Object      | {}                              | Override default config of the underlying library. For all parameters see [original library](https://github.com/orestbida/cookieconsent#all-available-options). |
-| `on*` callbacks | function    | (cookie, cookieConsent) => {}   | See below for configurable callbacks. |
+| Option          | Type        | Default value                      | Description                                                                                                                               |
+|-----------------|-------------|------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `autodetectLang`| boolean     | `true`                             | Autodetect language based on the value of `<html lang="...">`. If autodetect fails or if unsupported language is detected, fallback to `defaultLang`.<br>When disabled, force language to `defaultLang`. |
+| `defaultLang`   | string      | `'cs'`                             | Default language. One of `cs`, `de`, `en`, `hu`, `pl`, `ru`, `sk`, `uk`. This language will be used when autodetect is disabled or when it fails. |
+| `companyNames`  | array       | `['LMC']`                          | Array of strings with company names. Adjust only when the consent needs to be given to multiple companies. [See example][examples-configuration]. |
+| `consentCollectorApiUrl`| ?string | `'https://ccm.lmc.cz/(...)'`   | URL of the API where user consent information is sent. Null to disable sending data to the API. |
+| `config`        | Object      | `{}`                               | Override default config of the underlying library. For all parameters see [original library](https://github.com/orestbida/cookieconsent#all-available-options). |
+| `on*` callbacks | function    | `(cookie, cookieConsent) => {}`    | See below for configurable callbacks. |
 
 ### Supported languages
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The package is a wrapper around [Cookie Consent] by [Orest Bida].
 
 1. [Basic usage](#basic-usage)
 1. [Loading the plugin](#loading-the-plugin)
-1. [Manage features depending on given consent](#manage-features-depending-on-given-consent)
+1. [Manage features depending on the given consent](#manage-features-depending-on-the-given-consent)
 1. [Configuration](#configuration)
 1. [Configuration options](#configuration-options)
 1. [Theming](#theming)
@@ -70,7 +70,7 @@ Once the plugin is loaded, you need to initialize it using `initLmcCookieConsent
 
 ### Via npm
 
-For projects with their own build process for javascript we recommend using the plugin
+For projects with their own build process for JavaScript, it is recommended to use the plugin
 via npm package [@lmc-eu/cookie-consent-manager](https://www.npmjs.com/package/@lmc-eu/cookie-consent-manager).
 
 1. Add the plugin to your dependencies:
@@ -134,7 +134,7 @@ Note: We prefer to use modern ESM import syntax so this is marked as legacy.
 
 *With Webpack:* Webpack prioritises the ESM import syntax over CommonJS import syntax. So resolve the `main` field as first: `resolve: { mainFields: ["main", /* ... */ ] },`
 
-## Manage features depending on given consent
+## Manage features depending on the given consent
 
 For "necessary" cookies it is not needed to check whether a user has given any consent.
 
@@ -143,13 +143,13 @@ consent category. This must be done *before* the respective cookie is set.
 
 ### Consent categories
 
-| Category          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-|-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `necessary`       | Strictly necessary cookies are essential for user to browse the website and use its features, such as accessing secure areas of the site. These cookies are first-party cookies.<br>Some examples of strictly necessary cookies: Session cookies, Cookie banner cookies, Load balancing cookies, CSFR tokens, Language selection cookies, Region / country cookies, Performance cookies, Application firewall cookies and JavaScript check cookies.<br>For these cookies you **don't need to check** whether user actually has this level. |
-| `ad`              | For cookies related to advertising                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| `analytics`       | For analysis and statistics                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| `functionality`   | For extended functionality (not covered by `necessary` category)                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `personalization` | For personalization based on user profiling (recommendation etc.)                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| Category          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `necessary`       | Strictly necessary cookies are essential for user to browse the website and use its features, such as accessing secure areas of the site. These cookies are first-party cookies.<br>Some examples of strictly necessary cookies: Session cookies, Cookie banner cookies, Load balancing cookies, CSFR tokens, Language selection cookies, Region/country cookies, Performance cookies, Application firewall cookies and JavaScript check cookies.<br>For these cookies you **don't need to check** whether user actually has this level. |
+| `ad`              | For cookies related to advertising                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `analytics`       | For analysis and statistics                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `functionality`   | For extended functionality (not covered by `necessary` category)                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `personalization` | For personalization based on user profiling (recommendation, etc.)                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 
 ### GTM (Google Tag Manager) scripts
 
@@ -317,8 +317,8 @@ to [`sass`][sass] since all other Sass compilers (and the old `@import` rule) ar
 
 ### Without Spirit Design System
 
-Handful of CSS custom properties are available for you to customize the UI to make it match the design of your site.
-For example, to change text color of cookie consent UI, load the [default CSS](#basic-usage) and add the following code
+A handful of CSS custom properties are available for you to customize the UI to make it match the design of your site.
+For example, to change the text color of cookie consent UI, load the [default CSS](#basic-usage) and add the following code
 anywhere in your stylesheet (the order of which is not important):
 
 ```css
@@ -372,7 +372,7 @@ If you are not using cookie consent with the default design, additional steps ma
   }
   ```
 
-If you use custom font like this, make sure you don't load the default Inter font and that you use
+If you use a custom font like this, make sure you don't load the default Inter font and that you use
 `<link rel="preconnect" ...>` only to actually needed domains.
 
 ### Dark mode

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Provide configurable cookie consent banner with predefined LMC defaults. The UI 
 
 The package is a wrapper around [Cookie Consent] by [Orest Bida].
 
+## Table of contents
+
+1. [Basic usage](#basic-usage)
+1. [Loading the plugin](#loading-the-plugin)
+1. [Manage features depending on given consent](#manage-features-depending-on-given-consent)
+1. [Configuration](#configuration)
+1. [Configuration options](#configuration-options)
+1. [Theming](#theming)
+1. [Development and contributing](#development-and-contributing)
+
 ## Basic usage
 
 Make assets load faster by placing pre-connect headers right after `<meta charset>` in your `<head>`:
@@ -378,6 +388,8 @@ If your project does _not_ use Spirit, you still may adjust exposed CSS custom p
   --lmcccm-bg: #000;
 }
 ```
+
+[👀 See dark mode example][examples-theming]
 
 ## Development and contributing
 

--- a/examples/configuration.html
+++ b/examples/configuration.html
@@ -41,7 +41,7 @@
 
             <h1 class="display-1 mt-md-3">Extended Configuration</h1>
             <p class="lead mb-4 mb-md-5">
-                This is an example of extended configuration.
+                This is an example of an extended configuration.
             </p>
 
             <ul class="nav nav-pills justify-content-center mb-3">
@@ -71,11 +71,28 @@
         <div class="row justify-content-lg-center">
             <div class="col col-lg-10 col-xl-8">
 
+                <h2 class="mt-md-3 mb-3">What is shown here</h2>
+
+                <ul class="mb-4">
+                    <li>Forcing specific language – Slovak (using <code>defaultLang</code>), ie. disabling auto-detection (<code>autodetectLang</code>)</li>
+                    <li>Setting multiple company names in the consent text (<code>companyNames</code>)</li>
+                    <li>
+                        Overwriting raw configuration of the underlying cookie-consent component (via <code>config</code> option),
+                        to modify some advanced features.
+                    </li>
+                    <li>Clearing localStorage if user gives consent to only necessary data (<code>onFirstAcceptOnlyNecessary</code>)</li>
+                    <li>Etc.</li>
+                </ul>
+
+                <p class="mb-4">
+                    See page source for details.
+                </p>
+
                 <h2 class="mt-md-3 mb-3">Use cookieConsent instance</h2>
 
                 <p class="mb-4">
-                    When <a href="https://github.com/lmc-eu/cookie-consent-manager#callbacks">callbacks</a> does not satisfy
-                    your needs to conditional code execution, you can also store cookieConsent instance in a variable
+                    When <a href="https://github.com/lmc-eu/cookie-consent-manager#callbacks">callbacks</a> don't satisfy
+                    your needs for conditional code execution, you can also store cookieConsent instance in a variable
                     and access it later when needed – see source code.
                 </p>
 
@@ -106,7 +123,7 @@
       'github.example',
       {
         autodetectLang: false, // do not detect language from the `<html lang="...">` value
-        defaultLang: 'en', // force use of 'en' language instead
+        defaultLang: 'sk', // force use of 'sk' language instead
         companyNames: ['LMC', 'Some Other Company', 'ACME'], // define custom company names to be shown in the consent text
         consentCollectorApiUrl: 'https://ccm.lmc.cz/local-data-acceptation-data-entries?Spot=(public,demo)', // override default URL for demo purposes; do not set custom consentCollectorApiUrl unless you have been explicitly guided to do so!
         config: { // override default config of the underlying library, see https://github.com/orestbida/cookieconsent#all-available-options


### PR DESCRIPTION
I would add this despite the "auto-TOC" GitHub provides: 

![obrazek](https://user-images.githubusercontent.com/793041/144141225-e4ef1cf9-dde8-4832-a883-d3f8a64ed775.png)

Its nice... But hidden. Better to have the links and quick overview what is in the README right in front of the eyes :eyes: .