### PR TITLE
Chore: Disable dependabot because of doing lot of noise

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: daily
       timezone: Europe/Prague
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0
     versioning-strategy: increase-if-necessary
     commit-message:
       prefix: Deps


### PR DESCRIPTION
Limiting dependabot PRs to zero to disable it until we come with better solution.