### PR TITLE
Chore(renovate): Set `separateMajorMinor` to false for devDependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,13 +13,6 @@
   "commitMessagePrefix": "Deps: ",
   "packageRules": [
     {
-      "groupName": "all dev dependencies",
-      "groupSlug": "all-dev",
-      "matchPackagePatterns": ["*"],
-      "matchUpdateTypes": ["*"],
-      "matchDepTypes": ["devDependencies"]
-    },
-    {
       "groupName": "major prod dependencies",
       "groupSlug": "major-prod",
       "matchPackagePatterns": ["*"],
@@ -32,6 +25,13 @@
       "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["minor", "patch"],
       "matchDepTypes": ["dependencies"]
+    },
+    {
+      "groupName": "all dev dependencies",
+      "groupSlug": "all-dev",
+      "separateMajorMinor": false,
+      "matchPackagePatterns": ["*"],
+      "matchDepTypes": ["devDependencies"]
     }
   ]
 }


### PR DESCRIPTION
Tested on https://github.com/literat/literat/pull/18