### PR TITLE
Docs(lighthouse): Fix errors reported by Google Lighthouse in examples

### DIFF
--- a/examples/callbacks.html
+++ b/examples/callbacks.html
@@ -8,6 +8,7 @@
 
     <title>Cookie Consent Manager – callbacks example</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Cookie Consent Manager – callbacks example">
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.0/font/bootstrap-icons.css">
@@ -30,8 +31,8 @@
             <span class="fs-5">Cookie Consent Manager</span>
         </a>
         <div>
-            <a class="btn btn-outline-primary me-2" href="https://github.com/lmc-eu/cookie-consent/#readme" target="_blank">Documentation</a>
-            <a class="btn btn-primary" href="https://github.com/lmc-eu/cookie-consent/releases" target="_blank">Download</a>
+            <a class="btn btn-outline-primary me-2" href="https://github.com/lmc-eu/cookie-consent/#readme" target="_blank" rel="noopener noreferrer">Documentation</a>
+            <a class="btn btn-primary" href="https://github.com/lmc-eu/cookie-consent/releases" target="_blank" rel="noopener noreferrer">Download</a>
         </div>
     </div>
 </header>

--- a/examples/configuration.html
+++ b/examples/configuration.html
@@ -8,6 +8,7 @@
 
     <title>Cookie Consent Manager – extended configuration example</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Cookie Consent Manager – extended configuration example">
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.0/font/bootstrap-icons.css">
@@ -30,8 +31,8 @@
             <span class="fs-5">Cookie Consent Manager</span>
         </a>
         <div>
-            <a class="btn btn-outline-primary me-2" href="https://github.com/lmc-eu/cookie-consent/#readme" target="_blank">Documentation</a>
-            <a class="btn btn-primary" href="https://github.com/lmc-eu/cookie-consent/releases" target="_blank">Download</a>
+            <a class="btn btn-outline-primary me-2" href="https://github.com/lmc-eu/cookie-consent/#readme" target="_blank" rel="noopener noreferrer">Documentation</a>
+            <a class="btn btn-primary" href="https://github.com/lmc-eu/cookie-consent/releases" target="_blank" rel="noopener noreferrer">Download</a>
         </div>
     </div>
 </header>

--- a/examples/index.html
+++ b/examples/index.html
@@ -8,6 +8,7 @@
 
     <title>Cookie Consent Manager – example</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Cookie Consent Manager – example">
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.0/font/bootstrap-icons.css">
@@ -34,8 +35,8 @@
             <span class="fs-5">Cookie Consent Manager</span>
         </a>
         <div>
-            <a class="btn btn-outline-primary me-2" href="https://github.com/lmc-eu/cookie-consent/#readme" target="_blank">Documentation</a>
-            <a class="btn btn-primary" href="https://github.com/lmc-eu/cookie-consent/releases" target="_blank">Download</a>
+            <a class="btn btn-outline-primary me-2" href="https://github.com/lmc-eu/cookie-consent/#readme" target="_blank" rel="noopener noreferrer">Documentation</a>
+            <a class="btn btn-primary" href="https://github.com/lmc-eu/cookie-consent/releases" target="_blank" rel="noopener noreferrer">Download</a>
         </div>
     </div>
 </header>

--- a/examples/theming.html
+++ b/examples/theming.html
@@ -8,6 +8,7 @@
 
     <title>Cookie Consent Manager – theming example</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Cookie Consent Manager – theming example">
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.0/font/bootstrap-icons.css">
@@ -66,8 +67,8 @@
             <span class="fs-5">Cookie Consent Manager</span>
         </a>
         <div>
-            <a class="btn btn-outline-primary me-2" href="https://github.com/lmc-eu/cookie-consent/#readme" target="_blank">Documentation</a>
-            <a class="btn btn-primary" href="https://github.com/lmc-eu/cookie-consent/releases" target="_blank">Download</a>
+            <a class="btn btn-outline-primary me-2" href="https://github.com/lmc-eu/cookie-consent/#readme" target="_blank" rel="noopener noreferrer">Documentation</a>
+            <a class="btn btn-primary" href="https://github.com/lmc-eu/cookie-consent/releases" target="_blank" rel="noopener noreferrer">Download</a>
         </div>
     </div>
 </header>


### PR DESCRIPTION
  * missing meta description
  * missing `noopener` and `norefferer` for cross-origin links