### PR TITLE
Chore: Do not lint build.js in examples

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -15,3 +15,6 @@ dist
 
 # Some tools use this pattern for their configuration files. Lint them!
 !*.config.js
+
+# Do not lint build output in examples
+examples/*/bundle.js


### PR DESCRIPTION
If you have `build.js` in `examples/webpack*/` and run `yarn lint` in the root directory, it will find in the build.js exactly `1072 problems (924 errors, 148 warnings)` :upside_down_face: .