### PR TITLE
Chore: Annotate the CommonJS export names for ESM import in Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   "browser": {
     "./LmcCookieConsentManager.js": "./LmcCookieConsentManager.js",
     "./LmcCookieConsentManager.cjs": "./LmcCookieConsentManager.cjs",
-    "./LmcCookieConsentManager.mjs": "./LmcCookieConsentManager.mjs",
-    "crypto": false
+    "./LmcCookieConsentManager.mjs": "./LmcCookieConsentManager.mjs"
   },
   "repository": {
     "type": "git",
@@ -47,7 +46,7 @@
     "prebuild": "npm-run-all --serial build:clean build:copy",
     "build:clean": "rm -rf dist && mkdir -p dist/scss",
     "build:copy": "cp package.json README.md src/LmcCookieConsentManager.scss dist/ && cp -r src/scss/* dist/scss/",
-    "build": "npm-run-all --serial js:compile css",
+    "build": "npm-run-all --serial js css",
     "start": "node scripts/serve.js",
     "format": "yarn format:check",
     "format:check": "prettier --check 'src/**/*.{js,jsx,ts,tsx,scss}' 'scripts/*'",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 const { build } = require('esbuild');
-const replace = require('replace-in-file');
+const fs = require('fs');
 
 // iife
 build({
@@ -31,30 +31,25 @@ build({
   bundle: true,
   target: 'es6',
   outfile: 'dist/LmcCookieConsentManager.cjs',
-  platform: 'node',
+  platform: 'browser',
   format: 'cjs',
   /**
    * the "main" field was ignored (main fields must be configured manually when using the "neutral" platform)
    * because vanilla-cookie-consent is set as `main` in package.json
    */
   mainFields: ['main'],
-})
-  .then(() => {
-    const options = {
-      files: './dist/LmcCookieConsentManager.cjs',
-      from: /0 && \(module.exports = {}\);/gm,
-      to: 'module.exports = LmcCookieConsentManager_default;',
-    };
-
-    replace(options)
-      .then((results) => {
-        console.log('Replacement results:', results);
-      })
-      .catch((error) => {
-        console.error('Error occurred:', error);
-      });
-  })
-  .catch((error) => {
-    console.error(error);
-    process.exit(1);
-  });
+}).then(() => {
+  // Annotate the CommonJS export names for ESM import in node
+  fs.appendFile(
+    './dist/LmcCookieConsentManager.cjs',
+    `// Annotate the CommonJS export names for ESM import in node:
+module.exports = LmcCookieConsentManager_default;
+`,
+    (error) => {
+      if (error) {
+        console.log(error);
+        process.exit(1);
+      }
+    },
+  );
+});


### PR DESCRIPTION
  * we need to build commonjs module as `browser` to avoid nanoid using
    crypto module which is native node.js module
  * instead of that we want to use web crypto api
  * using `platform:browser` bundler finds right export from nanoid and
    use it
  * but for this platform bundler did not annotate the commonjs export
    so we must do it manually