### PR TITLE
Chore: Improve jest tests performance

### DIFF
--- a/config/jest.config.json
+++ b/config/jest.config.json
@@ -6,5 +6,10 @@
   "testPathIgnorePatterns": [
     "/node_modules/",
     "/dist/"
-  ]
+  ],
+  "globals": {
+    "ts-jest": {
+      "isolatedModules": true
+    }
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
   ],
   "exclude": [
     "./dist",
+    "./examples",
   ],
   "ts-node": {
     "compilerOptions": {


### PR DESCRIPTION
Running tests get unacceptably slow when switching to ts-jest.

On my machine:
- Before: ~1,5 secs
- After: 11 secs :flushed: 

On github actions:
- Before: ~2 secs
- After: ~5 secs

So here are some changes to make jest running faster:
- Do not include examples directory in tsconfig
- Use only one runner (with current number of tests the overhead cost is bigger then benefit). This decreases the time by ~30 % on my 4 CPU machine. Has no measurable impact on github actions, though.
- Use `isolatedModules: true`, [see docs](https://github.com/kulshekhar/ts-jest/blob/main/website/docs/getting-started/options/isolatedModules.md). We lose type-checking in tests, however, as we run `tsc -p` just the step before, its probably redundant. This gets the final time to:
   - On my machine: ~2 secs (so <0.5  sec difference)
   - On github actions: ~2 secs (the same as before)