### PR TITLE
Refactor: Use category instead of level in type names

### DIFF
--- a/src/LmcCookieConsentManager.ts
+++ b/src/LmcCookieConsentManager.ts
@@ -9,7 +9,7 @@ import { config as configRu } from './languages/ru';
 import { config as configSk } from './languages/sk';
 import { config as configUk } from './languages/uk';
 import submitConsent from './consentCollector';
-import { CookieConsentLevel, OnAcceptCallback, CookieConsentManagerOptions, CookieConsentManager } from './types';
+import { CookieConsentCategory, OnAcceptCallback, CookieConsentManagerOptions, CookieConsentManager } from './types';
 import { VanillaCookieConsent } from './types/vanilla-cookieconsent';
 
 /* eslint-disable-next-line no-unused-vars */
@@ -50,7 +50,7 @@ const defaultOptions: CookieConsentManagerOptions = {
  *   to be given to multiple companies.
  * @param {VanillaCookieConsent.Options} [args.config] - Override default config.
  *   See https://github.com/orestbida/cookieconsent/blob/master/Readme.md#all-available-options
- * @returns {VanillaCookieConsent.CookieConsent<CookieConsentLevel>} Instance of the underlying CookieConsent component.
+ * @returns {VanillaCookieConsent.CookieConsent<CookieConsentCategory>} Instance of the underlying CookieConsent component.
  *   For available API, see https://github.com/orestbida/cookieconsent#apis--configuration-parameters
  */
 const LmcCookieConsentManager: CookieConsentManager = (serviceName, args) => {
@@ -105,9 +105,9 @@ const LmcCookieConsentManager: CookieConsentManager = (serviceName, args) => {
         transition: VanillaCookieConsent.Transition.SLIDE, // zoom/slide
       },
     },
-    onAccept: (cookie: VanillaCookieConsent.Cookie<CookieConsentLevel>) => {
+    onAccept: (cookie: VanillaCookieConsent.Cookie<CookieConsentCategory>) => {
       const givenLevels = cookieConsent.get('level');
-      const acceptedOnlyNecessary = givenLevels.length === 1 && givenLevels[0] === CookieConsentLevel.NECESSARY;
+      const acceptedOnlyNecessary = givenLevels.length === 1 && givenLevels[0] === CookieConsentCategory.NECESSARY;
 
       onAccept(cookie, cookieConsent);
 
@@ -144,15 +144,15 @@ const LmcCookieConsentManager: CookieConsentManager = (serviceName, args) => {
   return cookieConsent;
 };
 
-function pushToDataLayer(cookie: VanillaCookieConsent.Cookie<CookieConsentLevel>) {
+function pushToDataLayer(cookie: VanillaCookieConsent.Cookie<CookieConsentCategory>) {
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({
     event: 'CookieConsent-update',
-    'CookieConsent.necessary': cookie.level.includes(CookieConsentLevel.NECESSARY),
-    'CookieConsent.analytics': cookie.level.includes(CookieConsentLevel.ANALYTICS),
-    'CookieConsent.ad': cookie.level.includes(CookieConsentLevel.AD),
-    'CookieConsent.functionality': cookie.level.includes(CookieConsentLevel.FUNCTIONALITY),
-    'CookieConsent.personalization': cookie.level.includes(CookieConsentLevel.PERSONALIZATION),
+    'CookieConsent.necessary': cookie.level.includes(CookieConsentCategory.NECESSARY),
+    'CookieConsent.analytics': cookie.level.includes(CookieConsentCategory.ANALYTICS),
+    'CookieConsent.ad': cookie.level.includes(CookieConsentCategory.AD),
+    'CookieConsent.functionality': cookie.level.includes(CookieConsentCategory.FUNCTIONALITY),
+    'CookieConsent.personalization': cookie.level.includes(CookieConsentCategory.PERSONALIZATION),
     'CookieConsent.revision': cookie.revision,
   });
 }

--- a/src/consentCollector.ts
+++ b/src/consentCollector.ts
@@ -1,4 +1,4 @@
-import { CookieConsentLevel } from './types';
+import { CookieConsentCategory } from './types';
 import { VanillaCookieConsent } from './types/vanilla-cookieconsent';
 
 /**
@@ -6,7 +6,7 @@ import { VanillaCookieConsent } from './types/vanilla-cookieconsent';
  */
 function submitConsent(
   consentCollectorApiUrl: string,
-  cookieConsent: VanillaCookieConsent.CookieConsent<CookieConsentLevel>,
+  cookieConsent: VanillaCookieConsent.CookieConsent<CookieConsentCategory>,
   acceptedOnlyNecessary: boolean,
 ): void {
   const payload = buildPayload(cookieConsent, acceptedOnlyNecessary);
@@ -15,7 +15,7 @@ function submitConsent(
 }
 
 function buildPayload(
-  cookieConsent: VanillaCookieConsent.CookieConsent<CookieConsentLevel>,
+  cookieConsent: VanillaCookieConsent.CookieConsent<CookieConsentCategory>,
   acceptedOnlyNecessary: boolean,
 ): Object {
   const cookieData = cookieConsent.get('data');
@@ -24,10 +24,10 @@ function buildPayload(
   // https://github.com/orestbida/cookieconsent/discussions/90#discussioncomment-1466886
   const rejectedCategories = acceptedOnlyNecessary
     ? [
-        CookieConsentLevel.AD,
-        CookieConsentLevel.ANALYTICS,
-        CookieConsentLevel.FUNCTIONALITY,
-        CookieConsentLevel.PERSONALIZATION,
+        CookieConsentCategory.AD,
+        CookieConsentCategory.ANALYTICS,
+        CookieConsentCategory.FUNCTIONALITY,
+        CookieConsentCategory.PERSONALIZATION,
       ]
     : [];
 

--- a/src/languages/cs.ts
+++ b/src/languages/cs.ts
@@ -1,5 +1,5 @@
 import { addSeparators, pluralize } from '../utils';
-import { ExtraMessages, CookieConsentLevel } from '../types';
+import { ExtraMessages, CookieConsentCategory } from '../types';
 import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
@@ -41,35 +41,35 @@ export const config = (extraMessages: ExtraMessages): VanillaCookieConsent.Langu
       blocks: [
         {
           toggle: {
-            value: CookieConsentLevel.NECESSARY,
+            value: CookieConsentCategory.NECESSARY,
             enabled: true,
             readonly: true,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.AD,
+            value: CookieConsentCategory.AD,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.ANALYTICS,
+            value: CookieConsentCategory.ANALYTICS,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.FUNCTIONALITY,
+            value: CookieConsentCategory.FUNCTIONALITY,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.PERSONALIZATION,
+            value: CookieConsentCategory.PERSONALIZATION,
             enabled: false,
             readonly: false,
           },

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -1,5 +1,5 @@
 import { addSeparators } from '../utils';
-import { ExtraMessages, CookieConsentLevel } from '../types';
+import { ExtraMessages, CookieConsentCategory } from '../types';
 import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
@@ -35,35 +35,35 @@ export const config = (extraMessages: ExtraMessages): VanillaCookieConsent.Langu
       blocks: [
         {
           toggle: {
-            value: CookieConsentLevel.NECESSARY,
+            value: CookieConsentCategory.NECESSARY,
             enabled: true,
             readonly: true,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.AD,
+            value: CookieConsentCategory.AD,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.ANALYTICS,
+            value: CookieConsentCategory.ANALYTICS,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.FUNCTIONALITY,
+            value: CookieConsentCategory.FUNCTIONALITY,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.PERSONALIZATION,
+            value: CookieConsentCategory.PERSONALIZATION,
             enabled: false,
             readonly: false,
           },

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1,5 +1,5 @@
 import { addSeparators } from '../utils';
-import { ExtraMessages, CookieConsentLevel } from '../types';
+import { ExtraMessages, CookieConsentCategory } from '../types';
 import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
@@ -34,35 +34,35 @@ export const config = (extraMessages: ExtraMessages): VanillaCookieConsent.Langu
       blocks: [
         {
           toggle: {
-            value: CookieConsentLevel.NECESSARY,
+            value: CookieConsentCategory.NECESSARY,
             enabled: true,
             readonly: true,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.AD,
+            value: CookieConsentCategory.AD,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.ANALYTICS,
+            value: CookieConsentCategory.ANALYTICS,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.FUNCTIONALITY,
+            value: CookieConsentCategory.FUNCTIONALITY,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.PERSONALIZATION,
+            value: CookieConsentCategory.PERSONALIZATION,
             enabled: false,
             readonly: false,
           },

--- a/src/languages/hu.ts
+++ b/src/languages/hu.ts
@@ -1,5 +1,5 @@
 import { addSeparators } from '../utils';
-import { ExtraMessages, CookieConsentLevel } from '../types';
+import { ExtraMessages, CookieConsentCategory } from '../types';
 import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
@@ -35,35 +35,35 @@ export const config = (extraMessages: ExtraMessages): VanillaCookieConsent.Langu
       blocks: [
         {
           toggle: {
-            value: CookieConsentLevel.NECESSARY,
+            value: CookieConsentCategory.NECESSARY,
             enabled: true,
             readonly: true,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.AD,
+            value: CookieConsentCategory.AD,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.ANALYTICS,
+            value: CookieConsentCategory.ANALYTICS,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.FUNCTIONALITY,
+            value: CookieConsentCategory.FUNCTIONALITY,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.PERSONALIZATION,
+            value: CookieConsentCategory.PERSONALIZATION,
             enabled: false,
             readonly: false,
           },

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -1,5 +1,5 @@
 import { addSeparators } from '../utils';
-import { ExtraMessages, CookieConsentLevel } from '../types';
+import { ExtraMessages, CookieConsentCategory } from '../types';
 import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
@@ -35,35 +35,35 @@ export const config = (extraMessages: ExtraMessages): VanillaCookieConsent.Langu
       blocks: [
         {
           toggle: {
-            value: CookieConsentLevel.NECESSARY,
+            value: CookieConsentCategory.NECESSARY,
             enabled: true,
             readonly: true,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.AD,
+            value: CookieConsentCategory.AD,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.ANALYTICS,
+            value: CookieConsentCategory.ANALYTICS,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.FUNCTIONALITY,
+            value: CookieConsentCategory.FUNCTIONALITY,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.PERSONALIZATION,
+            value: CookieConsentCategory.PERSONALIZATION,
             enabled: false,
             readonly: false,
           },

--- a/src/languages/ru.ts
+++ b/src/languages/ru.ts
@@ -1,5 +1,5 @@
 import { addSeparators, pluralize } from '../utils';
-import { ExtraMessages, CookieConsentLevel } from '../types';
+import { ExtraMessages, CookieConsentCategory } from '../types';
 import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
@@ -41,35 +41,35 @@ export const config = (extraMessages: ExtraMessages): VanillaCookieConsent.Langu
       blocks: [
         {
           toggle: {
-            value: CookieConsentLevel.NECESSARY,
+            value: CookieConsentCategory.NECESSARY,
             enabled: true,
             readonly: true,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.AD,
+            value: CookieConsentCategory.AD,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.ANALYTICS,
+            value: CookieConsentCategory.ANALYTICS,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.FUNCTIONALITY,
+            value: CookieConsentCategory.FUNCTIONALITY,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.PERSONALIZATION,
+            value: CookieConsentCategory.PERSONALIZATION,
             enabled: false,
             readonly: false,
           },

--- a/src/languages/sk.ts
+++ b/src/languages/sk.ts
@@ -1,5 +1,5 @@
 import { addSeparators, pluralize } from '../utils';
-import { ExtraMessages, CookieConsentLevel } from '../types';
+import { ExtraMessages, CookieConsentCategory } from '../types';
 import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
@@ -41,35 +41,35 @@ export const config = (extraMessages: ExtraMessages): VanillaCookieConsent.Langu
       blocks: [
         {
           toggle: {
-            value: CookieConsentLevel.NECESSARY,
+            value: CookieConsentCategory.NECESSARY,
             enabled: true,
             readonly: true,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.AD,
+            value: CookieConsentCategory.AD,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.ANALYTICS,
+            value: CookieConsentCategory.ANALYTICS,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.FUNCTIONALITY,
+            value: CookieConsentCategory.FUNCTIONALITY,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.PERSONALIZATION,
+            value: CookieConsentCategory.PERSONALIZATION,
             enabled: false,
             readonly: false,
           },

--- a/src/languages/uk.ts
+++ b/src/languages/uk.ts
@@ -1,5 +1,5 @@
 import { addSeparators, pluralize } from '../utils';
-import { ExtraMessages, CookieConsentLevel } from '../types';
+import { ExtraMessages, CookieConsentCategory } from '../types';
 import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
@@ -41,35 +41,35 @@ export const config = (extraMessages: ExtraMessages): VanillaCookieConsent.Langu
       blocks: [
         {
           toggle: {
-            value: CookieConsentLevel.NECESSARY,
+            value: CookieConsentCategory.NECESSARY,
             enabled: true,
             readonly: true,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.AD,
+            value: CookieConsentCategory.AD,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.ANALYTICS,
+            value: CookieConsentCategory.ANALYTICS,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.FUNCTIONALITY,
+            value: CookieConsentCategory.FUNCTIONALITY,
             enabled: false,
             readonly: false,
           },
         },
         {
           toggle: {
-            value: CookieConsentLevel.PERSONALIZATION,
+            value: CookieConsentCategory.PERSONALIZATION,
             enabled: false,
             readonly: false,
           },

--- a/src/types/CookieConsentCategory.ts
+++ b/src/types/CookieConsentCategory.ts
@@ -1,4 +1,4 @@
-export enum CookieConsentLevel {
+export enum CookieConsentCategory {
   NECESSARY = 'necessary',
   AD = 'ad',
   ANALYTICS = 'analytics',

--- a/src/types/CookieConsentManager.ts
+++ b/src/types/CookieConsentManager.ts
@@ -1,9 +1,9 @@
-import { CookieConsentLevel } from './CookieConsentLevel';
+import { CookieConsentCategory } from './CookieConsentCategory';
 import { VanillaCookieConsent } from './vanilla-cookieconsent';
 
 export type OnAcceptCallback = (
-  cookie: VanillaCookieConsent.Cookie<CookieConsentLevel>,
-  cookieConsent: VanillaCookieConsent.CookieConsent<CookieConsentLevel>,
+  cookie: VanillaCookieConsent.Cookie<CookieConsentCategory>,
+  cookieConsent: VanillaCookieConsent.CookieConsent<CookieConsentCategory>,
 ) => void;
 
 export type CookieConsentManagerOptions = {
@@ -23,4 +23,4 @@ export type CookieConsentManagerOptions = {
 export type CookieConsentManager = (
   serviceName: string,
   args: CookieConsentManagerOptions,
-) => VanillaCookieConsent.CookieConsent<CookieConsentLevel>;
+) => VanillaCookieConsent.CookieConsent<CookieConsentCategory>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,3 @@
 export * from './Messages';
-export * from './CookieConsentLevel';
+export * from './CookieConsentCategory';
 export * from './CookieConsentManager';

--- a/src/types/vanilla-cookieconsent.ts
+++ b/src/types/vanilla-cookieconsent.ts
@@ -1,7 +1,7 @@
 export namespace VanillaCookieConsent {
-  export interface Cookie<Level> {
+  export interface Cookie<Category> {
     data: any;
-    level: Array<Level>;
+    level: Array<Category>;
     revision: number;
     rfc_cookie: boolean;
   }
@@ -10,13 +10,13 @@ export namespace VanillaCookieConsent {
    * Instance of the underlying CookieConsent component.
    *   For available API, see https://github.com/orestbida/cookieconsent#apis--configuration-parameters
    */
-  export type CookieConsent<Level> = {
+  export type CookieConsent<Category> = {
     get: (name: string) => any;
     set: (name: string, value: any) => void;
     run: (config: any) => void;
     validCookie: (name: string) => boolean;
     getConfig: (name: string) => any;
-    allowedCategory: (category: Level) => boolean;
+    allowedCategory: (category: Category) => boolean;
     eraseCookies: (cookies: string | string[], path?: string, domain?: string) => void;
   };
 


### PR DESCRIPTION
According to [this](https://github.com/orestbida/cookieconsent/issues/144#issuecomment-993448152), "category" should be used instead of "level", which is deprecated name. So lets use "category" everywhere we can. Which is everywhere except low-level-cookie content, which sadly uses the `level` field.

Also in README and in examples we already use category everywhere.