### PR TITLE
Fix: Fix spacing too big after core library upgrade

### DIFF
--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -123,6 +123,7 @@
     flex-shrink: 0;
     align-items: baseline;
     max-width: none;
+    margin-top: 0;
 }
 
 @media screen and (max-width: settings.$breakpoint-desktop-down) {


### PR DESCRIPTION
The unwanted spacing was introduced here: https://github.com/orestbida/cookieconsent/blame/350d295ae72ef3ce4358d51435908dabe89f7c2a/src/cookieconsent.css#L248

Before:
![obrazek](https://user-images.githubusercontent.com/5614085/147135325-57821938-cf19-42d5-bee6-a2725129c71e.png)

After:
<img width="428" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/147135388-2d20623a-3e38-4f11-be40-9e27abc40559.png">
