### PR TITLE
Chore(changelog): Add missing dependency on conventional-changelog-lmc-github

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@commitlint/cli": "16.0.1",
     "@lmc-eu/browserslist-config": "1.0.1",
     "@lmc-eu/commitlint-config": "1.0.9",
-    "@lmc-eu/conventional-changelog-lmc-bitbucket": "1.3.7",
+    "@lmc-eu/conventional-changelog-lmc-github": "1.0.1",
     "@lmc-eu/eslint-config-base": "1.1.1",
     "@lmc-eu/prettier-config": "1.2.1",
     "@lmc-eu/stylelint-config": "2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1538,10 +1538,18 @@
     "@commitlint/config-conventional" "^11.0.0"
     "@lmc-eu/conventional-changelog-lmc-bitbucket" "^1.3.7"
 
-"@lmc-eu/conventional-changelog-lmc-bitbucket@1.3.7", "@lmc-eu/conventional-changelog-lmc-bitbucket@^1.3.7":
+"@lmc-eu/conventional-changelog-lmc-bitbucket@^1.3.7":
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/@lmc-eu/conventional-changelog-lmc-bitbucket/-/conventional-changelog-lmc-bitbucket-1.3.7.tgz#8803092f66485d714af49461617d6e147aea2ba4"
   integrity sha512-U4k+PY7xNqTAq1KoC2xYchV80gFlXpcjFymh9YMz5ue6gz2M1Pek5DtB0dYoliET5AYV/X6FYlKoPvUkFLKVZw==
+  dependencies:
+    compare-func "^2.0.0"
+    q "^1.5.1"
+
+"@lmc-eu/conventional-changelog-lmc-github@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@lmc-eu/conventional-changelog-lmc-github/-/conventional-changelog-lmc-github-1.0.1.tgz#df96a23b66e05d27474fed77af5f13c7c1d42bdc"
+  integrity sha512-Oi+QIbbjODSOfTJ9jEyL865cFIeF1tnxV+F8nmFhNwmHpu7LXMiYgZ1CDSC7SI0eE/Oe1KtKSI5cT6drxKT8Cg==
   dependencies:
     compare-func "^2.0.0"
     q "^1.5.1"


### PR DESCRIPTION
Was omitted in #167.