### PR TITLE
Chore: Define codeowners using company e-mail rather than nickname

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @OndraM @literat @adamkudrna @crishpeen
+* ondrej.machulda@lmc.eu tomas.litera@lmc.eu adam.kudrna@lmc.eu jan.kryspin@lmc.eu


### PR DESCRIPTION
This is IMHO better practice for company projects.

Syntax documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file