### PR TITLE
Docs: Avoid inconsistent states in language selection example

### DIFF
--- a/examples/languages.html
+++ b/examples/languages.html
@@ -77,35 +77,35 @@
             <div class="col col-lg-10 col-xl-8">
                 <h2 class="mt-md-3 mb-3">Select language</h2>
                 <div class="form-check">
-                    <input type="radio" class="form-check-input" id="lang-select-cs" value="cs" checked name="lang-select" onclick="toggleLanguage();">
+                    <input type="radio" class="form-check-input" id="lang-select-cs" value="cs" autocomplete="off" checked name="lang-select" onclick="toggleLanguage();">
                     <label class="form-check-label" for="lang-select-cs">Czech</label>
                 </div>
                 <div class="form-check">
-                    <input type="radio" class="form-check-input" id="lang-select-de" value="de" name="lang-select" onclick="toggleLanguage();">
+                    <input type="radio" class="form-check-input" id="lang-select-de" value="de" autocomplete="off" name="lang-select" onclick="toggleLanguage();">
                     <label class="form-check-label" for="lang-select-de">German</label>
                 </div>
                 <div class="form-check">
-                    <input type="radio" class="form-check-input" id="lang-select-en" value="en" name="lang-select" onclick="toggleLanguage();">
+                    <input type="radio" class="form-check-input" id="lang-select-en" value="en" autocomplete="off" name="lang-select" onclick="toggleLanguage();">
                     <label class="form-check-label" for="lang-select-en">English</label>
                 </div>
                 <div class="form-check">
-                    <input type="radio" class="form-check-input" id="lang-select-hu" value="hu" name="lang-select" onclick="toggleLanguage();">
+                    <input type="radio" class="form-check-input" id="lang-select-hu" value="hu" autocomplete="off" name="lang-select" onclick="toggleLanguage();">
                     <label class="form-check-label" for="lang-select-hu">Hungarian</label>
                 </div>
                 <div class="form-check">
-                    <input type="radio" class="form-check-input" id="lang-select-pl" value="pl" name="lang-select" onclick="toggleLanguage();">
+                    <input type="radio" class="form-check-input" id="lang-select-pl" value="pl" autocomplete="off" name="lang-select" onclick="toggleLanguage();">
                     <label class="form-check-label" for="lang-select-pl">Polish</label>
                 </div>
                 <div class="form-check">
-                    <input type="radio" class="form-check-input" id="lang-select-ru" value="ru" name="lang-select" onclick="toggleLanguage();">
+                    <input type="radio" class="form-check-input" id="lang-select-ru" value="ru" autocomplete="off" name="lang-select" onclick="toggleLanguage();">
                     <label class="form-check-label" for="lang-select-ru">Russian</label>
                 </div>
                 <div class="form-check">
-                    <input type="radio" class="form-check-input" id="lang-select-sk" value="sk" name="lang-select" onclick="toggleLanguage();">
+                    <input type="radio" class="form-check-input" id="lang-select-sk" value="sk" autocomplete="off" name="lang-select" onclick="toggleLanguage();">
                     <label class="form-check-label" for="lang-select-sk">Slovak</label>
                 </div>
                 <div class="form-check">
-                    <input type="radio" class="form-check-input" id="lang-select-uk" value="uk" name="lang-select" onclick="toggleLanguage();">
+                    <input type="radio" class="form-check-input" id="lang-select-uk" value="uk" autocomplete="off" name="lang-select" onclick="toggleLanguage();">
                     <label class="form-check-label" for="lang-select-uk">Ukrainian</label>
                 </div>
             </div>


### PR DESCRIPTION
When selecting a language radio button and reloading the page, at least Firefox remembers the last selection. However as we don't detect the form state on page load and presume the first option is active, the state of the actual language used become inconsistent with the selected input.

This disables the "remember value after reload" feature making the first input always be the active one after page (re)load.