### PR TITLE
Docs: Prefer `DOMContentLoaded` over `load` event to render cookie consent modal earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Load the script and initialize the plugin right before ending `</body>` tag:
 ```html
 <script defer src="https://cdn.jsdelivr.net/npm/@lmc-eu/cookie-consent-manager@1/init.js"></script>
 <script>
-window.addEventListener('load', function () {
+window.addEventListener('DOMContentLoaded', function () {
   initLmcCookieConsentManager('demo.example'); // use the name of your service, like jobs.cz, seduo.pl etc.
 });
 </script>
@@ -87,7 +87,7 @@ via npm package [@lmc-eu/cookie-consent-manager](https://www.npmjs.com/package/@
     ```js
     import LmcCookieConsentManager from '@lmc-eu/cookie-consent-manager';
 
-    window.addEventListener('load', function () {
+    window.addEventListener('DOMContentLoaded', function () {
       LmcCookieConsentManager('demo.example'/* , optional plugin configuration */);
     });
     ```

--- a/examples/callbacks.html
+++ b/examples/callbacks.html
@@ -106,7 +106,7 @@
 
 <script defer src="../dist/init.js"></script>
 <script>
-  window.addEventListener('load', function () {
+  window.addEventListener('DOMContentLoaded', function () {
     window.ccm = initLmcCookieConsentManager( // note we store cookieConsent instance in global window.ccm variable
       'github.example',
       {

--- a/examples/configuration.html
+++ b/examples/configuration.html
@@ -127,7 +127,7 @@
 
 <script defer src="../dist/init.js"></script>
 <script>
-  window.addEventListener('load', function () {
+  window.addEventListener('DOMContentLoaded', function () {
     window.ccm = initLmcCookieConsentManager( // note we store cookieConsent instance in global window.ccm variable
       'github.example',
       {

--- a/examples/index.html
+++ b/examples/index.html
@@ -138,7 +138,7 @@
 
 <script defer src="../dist/init.js"></script><!-- You will load this from CDN instead -->
 <script>
-  window.addEventListener('load', function () {
+  window.addEventListener('DOMContentLoaded', function () {
     initLmcCookieConsentManager(
       'github.example',
       {

--- a/examples/languages.html
+++ b/examples/languages.html
@@ -128,7 +128,7 @@
 
 <script defer src="../dist/init.js"></script>
 <script>
-  window.addEventListener('load', function () {
+  window.addEventListener('DOMContentLoaded', function () {
     window.ccm = initLmcCookieConsentManager(
         'github.example',
         {

--- a/examples/theming.html
+++ b/examples/theming.html
@@ -220,7 +220,7 @@
 
 <script defer src="../dist/init.js"></script>
 <script>
-  window.addEventListener('load', function () {
+  window.addEventListener('DOMContentLoaded', function () {
     initLmcCookieConsentManager(
       'github.example',
       {

--- a/examples/webpack-with-esm/index.js
+++ b/examples/webpack-with-esm/index.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-unresolved
 import LmcCookieConsentManager from '@lmc-eu/cookie-consent-manager';
 
-window.addEventListener('load', () => {
+window.addEventListener('DOMContentLoaded', () => {
   LmcCookieConsentManager('example');
 });


### PR DESCRIPTION
> Scripts with `defer` always execute when the DOM is ready (but before `DOMContentLoaded` event).

— https://javascript.info/script-async-defer#defer