### PR TITLE
Fix: Disconnect settings modal close button from button styles

### DIFF
--- a/src/scss/style/_settings-modal.scss
+++ b/src/scss/style/_settings-modal.scss
@@ -106,11 +106,18 @@
     font-size: 1.8em;
     color: inherit;
     background-color: transparent;
+    border: none;
+    border-radius: 0;
 
     &::before,
     &::after {
         width: 2.5px;
         background-color: currentcolor;
+    }
+
+    &:hover,
+    &:active {
+        background-color: transparent;
     }
 }
 


### PR DESCRIPTION
To prevent close button from inheriting secondary button styles on hover:

<img width="234" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/156551979-730b85a8-e85c-47af-be3d-b33ff9343566.png">
