### PR TITLE
Fix: Provide type for vanilla cookie consent options

### DIFF
--- a/src/LmcCookieConsentManager.ts
+++ b/src/LmcCookieConsentManager.ts
@@ -52,7 +52,7 @@ const defaultOptions: CookieConsentManagerOptions = {
  *   to be given to multiple companies.
  * @param {DisplayMode} [args.displayMode] - `force` to show consent in a centered modal box and to block page until
  *   user action. `soft` to show consent in a banner on the bottom of the page.
- * @param {Record<String, TranslationOverride>} [args.translationOverrides] - Translation overrides for specified languages
+ * @param {Record<string, TranslationOverride>} [args.translationOverrides] - Translation overrides for specified languages
  * @param {VanillaCookieConsent.Options} [args.config] - Override default config.
  *   See https://github.com/orestbida/cookieconsent/blob/master/Readme.md#all-available-options
  * @returns {VanillaCookieConsent.CookieConsent<CookieConsentCategory>} Instance of the underlying CookieConsent component.
@@ -135,7 +135,7 @@ const LmcCookieConsentManager: CookieConsentManager = (serviceName, args) => {
     onChange(cookieConsent, categories);
   };
 
-  const cookieConsentConfig = {
+  const cookieConsentConfig: VanillaCookieConsent.Options<CookieConsentCategory> = {
     auto_language: autodetectLang ? 'document' : null, // Autodetect language based on `<html lang="...">` value
     autorun: true, // Show the cookie consent banner as soon as possible
     cookie_expiration: 365, // 1 year

--- a/src/types/CookieConsentManager.ts
+++ b/src/types/CookieConsentManager.ts
@@ -34,7 +34,7 @@ export type CookieConsentManagerOptions = {
   companyNames: string[];
   displayMode: DisplayMode;
   translationOverrides: Record<string, TranslationOverride>;
-  config: VanillaCookieConsent.Options;
+  config: VanillaCookieConsent.Options<CookieConsentCategory>;
 };
 
 export type CookieConsentManager = (

--- a/src/types/vanilla-cookieconsent.ts
+++ b/src/types/vanilla-cookieconsent.ts
@@ -127,7 +127,7 @@ export namespace VanillaCookieConsent {
 
   interface GuiSettingsModal {
     layout: GuiSettingsLayout;
-    position: GuiSettingsPosition;
+    position?: GuiSettingsPosition;
     transition?: Transition;
   }
 
@@ -136,7 +136,7 @@ export namespace VanillaCookieConsent {
     settings_modal?: GuiSettingsModal;
   }
 
-  export interface Options {
+  export interface Options<Category> {
     autorun?: boolean;
     delay?: number;
     cookie_expiration?: number;
@@ -156,9 +156,9 @@ export namespace VanillaCookieConsent {
     remove_cookie_tables?: boolean;
     hide_from_bots?: boolean;
     gui_options?: GuiOptions;
-    onAccept?: () => void;
-    onChange?: () => void;
-    onFirstAction?: () => void;
+    onAccept?: (cookie: Cookie<Category>) => void;
+    onChange?: (cookie: Cookie<Category>, changed_categories: Array<Category>) => void;
+    onFirstAction?: (user_preferences: UserPreferences<Category>, cookie: Cookie<Category>) => void;
     languages?: Record<string, Languages>;
   }
 }


### PR DESCRIPTION
  * ensure that vanilla cookie consent configuration is type safe
  * @see https://github.com/lmc-eu/cookie-consent-manager/pull/218#discussion_r818638417