### PR TITLE
Fix/isolated modules

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Test
+name: Test build
 
 on:
   push:
@@ -6,10 +6,13 @@ on:
     - cron: '0 9 * * *' # every day at 9:00
 
 jobs:
-  test:
-    name: Tests and linting
+  test-build:
+    name: Build example
     runs-on: ubuntu-20.04
     timeout-minutes: 5
+    strategy:
+      matrix:
+        example: [webpack-with-cjs, webpack-with-esm, webpack-with-typescript]
 
     steps:
       - name: Checkout
@@ -26,14 +29,8 @@ jobs:
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
 
-      - name: Lint
-        run: yarn lint
+      - name: Test build
+        run: yarn build
 
-      - name: Check code-style format
-        run: yarn format
-
-      - name: Check types
-        run: yarn types
-
-      - name: Unit tests
-        run: yarn test:unit
+      - name: Test example build
+        run: cd ./examples/${{ matrix.example }} && yarn && yarn build

--- a/examples/webpack-with-typescript/.gitignore
+++ b/examples/webpack-with-typescript/.gitignore
@@ -1,0 +1,3 @@
+bundle.js
+yarn.lock
+index.js

--- a/examples/webpack-with-typescript/README.md
+++ b/examples/webpack-with-typescript/README.md
@@ -1,0 +1,18 @@
+# Webpack with Typescript module
+
+This example shows how to integrate LMC Cookie Consent Manager with Webpack via ESM module using Typescript.
+
+## How to use
+
+Execute [npm][npm] or [Yarn][yarn] to bootstrap the example:
+
+```shell
+npm install
+# or
+yarn
+```
+
+Then run the `build` script and open `index.html` in your browser.
+
+[npm]:https://docs.npmjs.com/cli/init
+[yarn]:https://yarnpkg.com/lang/en/docs/cli/create/

--- a/examples/webpack-with-typescript/index.html
+++ b/examples/webpack-with-typescript/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
+    <title>Cookie Consent Manager – module example</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap">
+
+    <link rel="stylesheet" href="../../dist/LmcCookieConsentManager.min.css"><!-- You will load this from CDN instead -->
+
+</head>
+<body>
+<h1>LMC Cookie Consent Manager</h1>
+<script defer src="./bundle.js"></script>
+</body>
+</html>

--- a/examples/webpack-with-typescript/index.ts
+++ b/examples/webpack-with-typescript/index.ts
@@ -1,0 +1,15 @@
+// eslint-disable-next-line import/no-unresolved
+import LmcCookieConsentManager, { DisplayMode } from '@lmc-eu/cookie-consent-manager';
+
+const ccmArgs = {
+  displayMode: DisplayMode.SOFT,
+  config: {
+      cookie_name: 'lmc_ccm_example',
+      cookie_domain: 'example.com',
+      cookie_necessary_only_expiration: 30,
+  }
+};
+
+window.addEventListener('DOMContentLoaded', () => {
+  LmcCookieConsentManager('example', ccmArgs);
+});

--- a/examples/webpack-with-typescript/package.json
+++ b/examples/webpack-with-typescript/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@lmc-eu/cookie-consent-manager-example-typescript",
+  "version": "1.0.0",
+  "license": "MIT",
+  "devDependencies": {
+    "ts-loader": "^9.2.8",
+    "typescript": "^4.6.2",
+    "webpack": "^5.63.0",
+    "webpack-cli": "^4.9.1"
+  },
+  "dependencies": {
+    "@lmc-eu/cookie-consent-manager": "../../dist"
+  },
+  "scripts": {
+    "build": "webpack build --config ./webpack.config.js",
+    "types": "tsc -p ./tsconfig.json"
+  }
+}

--- a/examples/webpack-with-typescript/tsconfig.json
+++ b/examples/webpack-with-typescript/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "outDir": "./",
+    "noImplicitAny": true,
+    "module": "es6",
+    "target": "es5",
+    "jsx": "react",
+    "allowJs": true,
+    "moduleResolution": "node",
+    "isolatedModules": true
+  },
+  "include": [
+    "./index.ts"
+  ],
+  "exclude": [
+    "./bundle.js"
+  ],
+}

--- a/examples/webpack-with-typescript/webpack.config.js
+++ b/examples/webpack-with-typescript/webpack.config.js
@@ -1,0 +1,21 @@
+const path = require('path');
+
+module.exports = {
+  entry: './index.ts',
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+  },
+  output: {
+    path: path.resolve(__dirname, './'),
+    filename: 'bundle.js',
+  },
+};

--- a/src/LmcCookieConsentManager.ts
+++ b/src/LmcCookieConsentManager.ts
@@ -10,13 +10,13 @@ import { config as configSk } from './languages/sk';
 import { config as configUk } from './languages/uk';
 import submitConsent from './consentCollector';
 import {
-  CookieConsentCategory,
   CookieConsentManager,
   CookieConsentManagerOptions,
-  DisplayMode,
   OnAcceptCallback,
   OnChangeCallback,
+  CookieConsentCategoryValues,
 } from './types';
+import { CookieConsentCategory, DisplayMode } from './constants';
 import { VanillaCookieConsent } from './types/vanilla-cookieconsent';
 
 /* eslint-disable-next-line no-unused-vars */
@@ -55,7 +55,7 @@ const defaultOptions: CookieConsentManagerOptions = {
  * @param {Record<string, TranslationOverride>} [args.translationOverrides] - Translation overrides for specified languages
  * @param {VanillaCookieConsent.Options} [args.config] - Override default config.
  *   See https://github.com/orestbida/cookieconsent/blob/master/Readme.md#all-available-options
- * @returns {VanillaCookieConsent.CookieConsent<CookieConsentCategory>} Instance of the underlying CookieConsent component.
+ * @returns {VanillaCookieConsent.CookieConsent<CookieConsentCategoryValues>} Instance of the underlying CookieConsent component.
  *   For available API, see https://github.com/orestbida/cookieconsent#apis--configuration-parameters
  */
 const LmcCookieConsentManager: CookieConsentManager = (serviceName, args) => {
@@ -91,8 +91,8 @@ const LmcCookieConsentManager: CookieConsentManager = (serviceName, args) => {
   };
 
   const onFirstAcceptHandler = (
-    userPreferences: VanillaCookieConsent.UserPreferences<CookieConsentCategory>,
-    cookie: VanillaCookieConsent.Cookie<CookieConsentCategory>,
+    userPreferences: VanillaCookieConsent.UserPreferences<CookieConsentCategoryValues>,
+    cookie: VanillaCookieConsent.Cookie<CookieConsentCategoryValues>,
   ) => {
     const cookieData = cookieConsent.get('data');
     if (cookieData === null || !('uid' in cookieData)) {
@@ -116,8 +116,8 @@ const LmcCookieConsentManager: CookieConsentManager = (serviceName, args) => {
   };
 
   const onChangeHandler = (
-    cookie: VanillaCookieConsent.Cookie<CookieConsentCategory>,
-    changedCategories: Array<CookieConsentCategory>,
+    cookie: VanillaCookieConsent.Cookie<CookieConsentCategoryValues>,
+    changedCategories: Array<CookieConsentCategoryValues>,
   ) => {
     const userPreferences = cookieConsent.getUserPreferences();
     const categories = {
@@ -135,7 +135,7 @@ const LmcCookieConsentManager: CookieConsentManager = (serviceName, args) => {
     onChange(cookieConsent, categories);
   };
 
-  const cookieConsentConfig: VanillaCookieConsent.Options<CookieConsentCategory> = {
+  const cookieConsentConfig: VanillaCookieConsent.Options<CookieConsentCategoryValues> = {
     auto_language: autodetectLang ? 'document' : null, // Autodetect language based on `<html lang="...">` value
     autorun: true, // Show the cookie consent banner as soon as possible
     cookie_expiration: 365, // 1 year
@@ -178,7 +178,7 @@ const LmcCookieConsentManager: CookieConsentManager = (serviceName, args) => {
   return cookieConsent;
 };
 
-function pushToDataLayer(cookie: VanillaCookieConsent.Cookie<CookieConsentCategory>) {
+function pushToDataLayer(cookie: VanillaCookieConsent.Cookie<CookieConsentCategoryValues>) {
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({
     event: 'CookieConsent-update',

--- a/src/consentCollector.ts
+++ b/src/consentCollector.ts
@@ -1,4 +1,4 @@
-import { CookieConsentCategory } from './types';
+import { CookieConsentCategoryValues } from './types';
 import { VanillaCookieConsent } from './types/vanilla-cookieconsent';
 
 /**
@@ -6,14 +6,14 @@ import { VanillaCookieConsent } from './types/vanilla-cookieconsent';
  */
 function submitConsent(
   consentCollectorApiUrl: string,
-  cookieConsent: VanillaCookieConsent.CookieConsent<CookieConsentCategory>,
+  cookieConsent: VanillaCookieConsent.CookieConsent<CookieConsentCategoryValues>,
 ): void {
   const payload = buildPayload(cookieConsent);
 
   postDataToApi(consentCollectorApiUrl, payload);
 }
 
-function buildPayload(cookieConsent: VanillaCookieConsent.CookieConsent<CookieConsentCategory>): Object {
+function buildPayload(cookieConsent: VanillaCookieConsent.CookieConsent<CookieConsentCategoryValues>): Object {
   const cookieData = cookieConsent.get('data');
   const userPreferences = cookieConsent.getUserPreferences();
   const daysOfAcceptation =

--- a/src/constants/CookieConsentCategory.ts
+++ b/src/constants/CookieConsentCategory.ts
@@ -1,0 +1,7 @@
+export const CookieConsentCategory = {
+  NECESSARY: 'necessary',
+  AD: 'ad',
+  ANALYTICS: 'analytics',
+  FUNCTIONALITY: 'functionality',
+  PERSONALIZATION: 'personalization',
+};

--- a/src/constants/DisplayMode.ts
+++ b/src/constants/DisplayMode.ts
@@ -1,0 +1,4 @@
+export const DisplayMode = {
+  FORCE: 'force',
+  SOFT: 'soft',
+};

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,2 @@
+export * from './CookieConsentCategory';
+export * from './DisplayMode';

--- a/src/languages/cs.ts
+++ b/src/languages/cs.ts
@@ -1,5 +1,6 @@
 import { addSeparators, assembleDescriptionIntro, pluralize } from '../utils';
-import { CookieConsentCategory, ExtraMessages } from '../types';
+import { ExtraMessages } from '../types';
+import { CookieConsentCategory } from '../constants';
 import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
@@ -10,7 +11,7 @@ const extra = {
 
 /**
  * @param {ExtraMessages} [extraMessages] - Object with extra messages
- * @param {array} [extraMessages.companyNames] - Array of strings with company names used to parametrized translations
+ * @param {Array} [extraMessages.companyNames] - Array of strings with company names used to parametrized translations
  * @returns {VanillaCookieConsent.Languages} Object with translated messages
  */
 export const config = (extraMessages: ExtraMessages): VanillaCookieConsent.Languages => {

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -1,5 +1,6 @@
 import { addSeparators, assembleDescriptionIntro } from '../utils';
-import { ExtraMessages, CookieConsentCategory } from '../types';
+import { ExtraMessages } from '../types';
+import { CookieConsentCategory } from '../constants';
 import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
@@ -8,7 +9,7 @@ const extra = {
 
 /**
  * @param {ExtraMessages} [extraMessages] - Object with extra messages
- * @param {array} [extraMessages.companyNames] - Array of strings with company names used to parametrized translations
+ * @param {Array} [extraMessages.companyNames] - Array of strings with company names used to parametrized translations
  * @returns {VanillaCookieConsent.Languages} Object with translated messages
  */
 export const config = (extraMessages: ExtraMessages): VanillaCookieConsent.Languages => {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1,5 +1,6 @@
 import { addSeparators, assembleDescriptionIntro } from '../utils';
-import { ExtraMessages, CookieConsentCategory } from '../types';
+import { ExtraMessages } from '../types';
+import { CookieConsentCategory } from '../constants';
 import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
@@ -7,7 +8,7 @@ const extra = {
 };
 /**
  * @param {ExtraMessages} [extraMessages] - Object with extra messages
- * @param {array} [extraMessages.companyNames] - Array of strings with company names used to parametrized translations
+ * @param {Array} [extraMessages.companyNames] - Array of strings with company names used to parametrized translations
  * @returns {VanillaCookieConsent.Languages} Object with translated messages
  */
 export const config = (extraMessages: ExtraMessages): VanillaCookieConsent.Languages => {

--- a/src/languages/hu.ts
+++ b/src/languages/hu.ts
@@ -1,5 +1,6 @@
 import { addSeparators, assembleDescriptionIntro } from '../utils';
-import { ExtraMessages, CookieConsentCategory } from '../types';
+import { ExtraMessages } from '../types';
+import { CookieConsentCategory } from '../constants';
 import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
@@ -8,7 +9,7 @@ const extra = {
 
 /**
  * @param {ExtraMessages} [extraMessages] - Object with extra messages
- * @param {array} [extraMessages.companyNames] - Array of strings with company names used to parametrized translations
+ * @param {Array} [extraMessages.companyNames] - Array of strings with company names used to parametrized translations
  * @returns {VanillaCookieConsent.Languages} Object with translated messages
  */
 export const config = (extraMessages: ExtraMessages): VanillaCookieConsent.Languages => {

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -1,5 +1,6 @@
 import { addSeparators, assembleDescriptionIntro, pluralize } from '../utils';
-import { ExtraMessages, CookieConsentCategory } from '../types';
+import { ExtraMessages } from '../types';
+import { CookieConsentCategory } from '../constants';
 import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
@@ -10,7 +11,7 @@ const extra = {
 
 /**
  * @param {ExtraMessages} [extraMessages] - Object with extra messages
- * @param {array} [extraMessages.companyNames] - Array of strings with company names used to parametrized translations
+ * @param {Array} [extraMessages.companyNames] - Array of strings with company names used to parametrized translations
  * @returns {VanillaCookieConsent.Languages} Object with translated messages
  */
 export const config = (extraMessages: ExtraMessages): VanillaCookieConsent.Languages => {

--- a/src/languages/ru.ts
+++ b/src/languages/ru.ts
@@ -1,5 +1,6 @@
 import { addSeparators, assembleDescriptionIntro, pluralize } from '../utils';
-import { ExtraMessages, CookieConsentCategory } from '../types';
+import { ExtraMessages } from '../types';
+import { CookieConsentCategory } from '../constants';
 import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
@@ -10,7 +11,7 @@ const extra = {
 
 /**
  * @param {ExtraMessages} [extraMessages] - Object with extra messages
- * @param {array} [extraMessages.companyNames] - Array of strings with company names used to parametrized translations
+ * @param {Array} [extraMessages.companyNames] - Array of strings with company names used to parametrized translations
  * @returns {VanillaCookieConsent.Languages} Object with translated messages
  */
 export const config = (extraMessages: ExtraMessages): VanillaCookieConsent.Languages => {

--- a/src/languages/sk.ts
+++ b/src/languages/sk.ts
@@ -1,5 +1,6 @@
 import { addSeparators, assembleDescriptionIntro, pluralize } from '../utils';
-import { ExtraMessages, CookieConsentCategory } from '../types';
+import { ExtraMessages } from '../types';
+import { CookieConsentCategory } from '../constants';
 import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
@@ -10,7 +11,7 @@ const extra = {
 
 /**
  * @param {ExtraMessages} [extraMessages] - Object with extra messages
- * @param {array} [extraMessages.companyNames] - Array of strings with company names used to parametrized translations
+ * @param {Array} [extraMessages.companyNames] - Array of strings with company names used to parametrized translations
  * @returns {VanillaCookieConsent.Languages} Object with translated messages
  */
 export const config = (extraMessages: ExtraMessages): VanillaCookieConsent.Languages => {

--- a/src/languages/uk.ts
+++ b/src/languages/uk.ts
@@ -1,5 +1,6 @@
 import { addSeparators, assembleDescriptionIntro, pluralize } from '../utils';
-import { ExtraMessages, CookieConsentCategory } from '../types';
+import { ExtraMessages } from '../types';
+import { CookieConsentCategory } from '../constants';
 import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
@@ -10,7 +11,7 @@ const extra = {
 
 /**
  * @param {ExtraMessages} [extraMessages] - Object with extra messages
- * @param {array} [extraMessages.companyNames] - Array of strings with company names used to parametrized translations
+ * @param {Array} [extraMessages.companyNames] - Array of strings with company names used to parametrized translations
  * @returns {VanillaCookieConsent.Languages} Object with translated messages
  */
 export const config = (extraMessages: ExtraMessages): VanillaCookieConsent.Languages => {

--- a/src/types/CookieConsentCategory.ts
+++ b/src/types/CookieConsentCategory.ts
@@ -1,7 +1,0 @@
-export const enum CookieConsentCategory {
-  NECESSARY = 'necessary',
-  AD = 'ad',
-  ANALYTICS = 'analytics',
-  FUNCTIONALITY = 'functionality',
-  PERSONALIZATION = 'personalization',
-}

--- a/src/types/CookieConsentManager.ts
+++ b/src/types/CookieConsentManager.ts
@@ -1,23 +1,24 @@
-import { CookieConsentCategory } from './CookieConsentCategory';
+import { CookieConsentCategory, DisplayMode } from '../constants';
 import { VanillaCookieConsent } from './vanilla-cookieconsent';
 
+export type Values<T> = T[keyof T];
+
+export type CookieConsentCategoryValues = Values<typeof CookieConsentCategory>;
+
 export type CategoriesChangeset = {
-  accepted: CookieConsentCategory[];
-  rejected: CookieConsentCategory[];
-  changed: CookieConsentCategory[];
+  accepted: CookieConsentCategoryValues[];
+  rejected: CookieConsentCategoryValues[];
+  changed: CookieConsentCategoryValues[];
 };
 
-export type OnFirstAcceptCallback = (cookieConsent: VanillaCookieConsent.CookieConsent<CookieConsentCategory>) => void;
-export type OnAcceptCallback = (cookieConsent: VanillaCookieConsent.CookieConsent<CookieConsentCategory>) => void;
+export type OnFirstAcceptCallback = (
+  cookieConsent: VanillaCookieConsent.CookieConsent<CookieConsentCategoryValues>,
+) => void;
+export type OnAcceptCallback = (cookieConsent: VanillaCookieConsent.CookieConsent<CookieConsentCategoryValues>) => void;
 export type OnChangeCallback = (
-  cookieConsent: VanillaCookieConsent.CookieConsent<CookieConsentCategory>,
+  cookieConsent: VanillaCookieConsent.CookieConsent<CookieConsentCategoryValues>,
   categories: CategoriesChangeset,
 ) => void;
-
-export const enum DisplayMode {
-  FORCE = 'force',
-  SOFT = 'soft',
-}
 
 export type TranslationOverride = {
   consentTitle?: string;
@@ -32,12 +33,12 @@ export type CookieConsentManagerOptions = {
   onAccept: OnAcceptCallback;
   onChange: OnChangeCallback;
   companyNames: string[];
-  displayMode: DisplayMode;
+  displayMode: Values<typeof DisplayMode>;
   translationOverrides: Record<string, TranslationOverride>;
-  config: VanillaCookieConsent.Options<CookieConsentCategory>;
+  config: VanillaCookieConsent.Options<CookieConsentCategoryValues>;
 };
 
 export type CookieConsentManager = (
   serviceName: string,
   args?: Partial<CookieConsentManagerOptions>,
-) => VanillaCookieConsent.CookieConsent<CookieConsentCategory>;
+) => VanillaCookieConsent.CookieConsent<CookieConsentCategoryValues>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,2 @@
 export * from './Messages';
-export * from './CookieConsentCategory';
 export * from './CookieConsentManager';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "declaration": true,
-    "emitDeclarationOnly": true,
+    "emitDeclarationOnly": true
   },
   "include": [
     "./src"


### PR DESCRIPTION
* `export const enum` do not work well with `isolatedModules` options
* use rather object with named values
* we should do not export const enums ever in any library (for
   internal use it works well)
* @see: https://www.typescriptlang.org/tsconfig#isolatedModules
* @see: https://ncjamieson.com/dont-export-const-enums/
* @see: https://fettblog.eu/tidy-typescript-avoid-enums/