### PR TITLE
Chore: Test build on multiple node versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,12 +7,13 @@ on:
 
 jobs:
   test-build:
-    name: Build example
+    name: Build example (${{ matrix.example }}, node ${{ matrix.node-version }})
     runs-on: ubuntu-20.04
     timeout-minutes: 5
     strategy:
       matrix:
         example: [webpack-with-cjs, webpack-with-esm, webpack-with-typescript]
+        node-version: [16, 18]
 
     steps:
       - name: Checkout
@@ -21,7 +22,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ matrix.node-version }}
 
       - name: Fetch Git history
         run: git fetch --no-tags --depth=50 origin main


### PR DESCRIPTION
Would make sense to test this as well? To make sure the dependencies are resolved in installable tree.

This is currently failing, would be fixed after by #239 .