### PR TITLE
Chore: Update `nanoid` package to v3 branch only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,11 @@
       "separateMajorMinor": false,
       "matchPackagePatterns": ["*"],
       "matchDepTypes": ["devDependencies"]
+    },
+    {
+      "groupName": "NanoID with CJS support",
+      "matchPackageNames": ["nanoid"],
+      "allowedVersions": "<4"
     }
   ]
 }


### PR DESCRIPTION
Based on the declined upgrade of the nanoid to the v4 version which is not supporting CJS, I am telling to Renovate bot not to upgrade the nanoid to v4, until Prace.cz will support ESM.

https://github.com/lmc-eu/cookie-consent-manager/pull/247