### PR TITLE
Docs: Fix typo in changelog message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Dependencies
 
-- Update all dev dependencies ([b96f653](https://github.com/lmc-eu/cookie-csent-manager/commit/b96f653), [9176c98](https://github.com/lmc-eu/cookie-consent-manager/commit/9176c98), [a79c078](https://github.com/lmc-eu/cookie-consent-manager/commit/a79c078), [0c9337b](https://github.com/lmc-eu/cookie-consent-manager/commit/0c9337b), [88f6706](https://github.com/lmc-eu/cookie-consent-manager/commit/88f6706), [2e93c24](https://github.com/lmc-eu/cookie-consent-manager/commit/2e93c24), [d55c0b8](https://github.com/lmc-eu/cookie-consent-manager/commit/d55c0b8), [addb38e](https://github.com/lmc-eu/cookie-consent-manager/commit/addb38e))
+- Update all dev dependencies ([b96f653](https://github.com/lmc-eu/cookie-consent-manager/commit/b96f653), [9176c98](https://github.com/lmc-eu/cookie-consent-manager/commit/9176c98), [a79c078](https://github.com/lmc-eu/cookie-consent-manager/commit/a79c078), [0c9337b](https://github.com/lmc-eu/cookie-consent-manager/commit/0c9337b), [88f6706](https://github.com/lmc-eu/cookie-consent-manager/commit/88f6706), [2e93c24](https://github.com/lmc-eu/cookie-consent-manager/commit/2e93c24), [d55c0b8](https://github.com/lmc-eu/cookie-consent-manager/commit/d55c0b8), [addb38e](https://github.com/lmc-eu/cookie-consent-manager/commit/addb38e))
 - Update dependency @lmc-eu/spirit-design-tokens to ^0.17.0 ([f78a255](https://github.com/lmc-eu/cookie-consent-manager/commit/f78a255), [2d7d6e9](https://github.com/lmc-eu/cookie-consent-manager/commit/2d7d6e9), [23b1bfa](https://github.com/lmc-eu/cookie-consent-manager/commit/23b1bfa))
 
 ### Tests


### PR DESCRIPTION
`csent` -> `consent`