### PR TITLE
Chore: Freeze `vanilla-cookieconsent` to 2.8.0 or allow major release

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
     "group:recommended",
     ":prHourlyLimit2"
   ],
+  "baseBranches": ["release/v3"],
   "enabledManagers": ["npm"],
   "branchPrefix": "dependencies/",
   "commitMessagePrefix": "Deps: ",

--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,11 @@
       "groupName": "NanoID with CJS support",
       "matchPackageNames": ["nanoid"],
       "allowedVersions": "<4"
+    },
+    {
+      "groupName": "CookieConsent frozen to 2.8.0 or major version",
+      "matchPackageNames": ["vanilla-cookieconsent"],
+      "allowedVersions": "<=2.8.0 | >=3.0.0"
     }
   ]
 }


### PR DESCRIPTION
  * there are breaking changes in 2.8.1 and we are waiting to comming
    major release