### PR TITLE
Chore: Disable update of stylelint-config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,6 +42,11 @@
       "allowedVersions": "<4"
     },
     {
+      "groupName": "Stylelint Config before reordering",
+      "matchPackageNames": ["@lmc-eu/stylelint-config"],
+      "allowedVersions": "<5"
+    },
+    {
       "groupName": "CookieConsent frozen to 2.8.0 or major version",
       "matchPackageNames": ["vanilla-cookieconsent"],
       "allowedVersions": "<=2.8.0 || >=3.0.0"


### PR DESCRIPTION
  * @see: https://github.com/lmc-eu/cookie-consent-manager/pull/276

Renovate reads configuration from the main branch, so configuration modifications that were applied in the release/v3 branch were not accepted.