### PR TITLE
Fix: Cannot use 'in' operator to search for 'uid' in undefined

### DIFF
--- a/src/LmcCookieConsentManager.ts
+++ b/src/LmcCookieConsentManager.ts
@@ -99,7 +99,7 @@ const LmcCookieConsentManager: CookieConsentManager = (serviceName, args) => {
     cookie: VanillaCookieConsent.Cookie<CookieConsentCategoryValues>,
   ) => {
     const cookieData = cookieConsent.get('data');
-    if (cookieData === null || !('uid' in cookieData)) {
+    if (cookieData == null || !('uid' in cookieData)) {
       cookieConsent.set('data', {
         value: { serviceName, uid: nanoid() },
         mode: 'update',


### PR DESCRIPTION
There are cases when cookie is not present and `get('data')` returns `undefined`. It is probably caused by strict privacy settings of certain browsers.

See also: https://github.com/orestbida/cookieconsent/blob/v2.8.0/src/cookieconsent.js#L1783