### PR TITLE
Chore: Remove @adamkudrna and @crispeen from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* ondrej.machulda@lmc.eu tomas.litera@lmc.eu adam.kudrna@lmc.eu jan.kryspin@lmc.eu
+* ondrej.machulda@lmc.eu tomas.litera@lmc.eu


### PR DESCRIPTION
I think there is no need to have these two super ninja developers on each PR of this project ;-)