### PR TITLE
Feat: Extend types to allow cookie tables settings

### DIFF
--- a/src/languages/cs.ts
+++ b/src/languages/cs.ts
@@ -6,9 +6,8 @@ import {
   pluralize,
   legalizeLmc,
 } from '../utils';
-import { ExtraMessages, Values } from '../types';
+import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
 import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
-import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
   and: 'a',

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -5,9 +5,8 @@ import {
   isSettingsButtonNotShown,
   legalizeLmc,
 } from '../utils';
-import { ExtraMessages, Values } from '../types';
+import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
 import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
-import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
   and: 'und',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -5,9 +5,8 @@ import {
   isSettingsButtonNotShown,
   legalizeLmc,
 } from '../utils';
-import { ExtraMessages, Values } from '../types';
+import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
 import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
-import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
   and: 'and',

--- a/src/languages/hu.ts
+++ b/src/languages/hu.ts
@@ -5,9 +5,8 @@ import {
   isSettingsButtonNotShown,
   legalizeLmc,
 } from '../utils';
-import { ExtraMessages, Values } from '../types';
+import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
 import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
-import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
   and: 'és',

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -6,9 +6,8 @@ import {
   legalizeLmc,
   pluralize,
 } from '../utils';
-import { ExtraMessages, Values } from '../types';
+import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
 import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
-import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
   and: 'i',

--- a/src/languages/ru.ts
+++ b/src/languages/ru.ts
@@ -6,9 +6,8 @@ import {
   legalizeLmc,
   pluralize,
 } from '../utils';
-import { ExtraMessages, Values } from '../types';
+import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
 import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
-import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
   and: 'и',

--- a/src/languages/sk.ts
+++ b/src/languages/sk.ts
@@ -6,9 +6,8 @@ import {
   legalizeLmc,
   pluralize,
 } from '../utils';
-import { ExtraMessages, Values } from '../types';
+import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
 import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
-import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
   and: 'a',

--- a/src/languages/uk.ts
+++ b/src/languages/uk.ts
@@ -6,9 +6,8 @@ import {
   legalizeLmc,
   pluralize,
 } from '../utils';
-import { ExtraMessages, Values } from '../types';
+import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
 import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
-import { VanillaCookieConsent } from '../types/vanilla-cookieconsent';
 
 const extra = {
   and: 'i',

--- a/src/types/vanilla-cookieconsent.ts
+++ b/src/types/vanilla-cookieconsent.ts
@@ -59,10 +59,18 @@ export namespace VanillaCookieConsent {
     readonly?: boolean;
   }
 
+  interface CookieTableItem {
+    domain?: string;
+    path?: string;
+    is_regex?: boolean;
+    [key: string]: string | boolean | undefined;
+  }
+
   interface ModalBlock {
     title?: string;
     description?: string;
     toggle?: ModalBlockToggle;
+    cookie_table?: CookieTableItem[];
   }
 
   interface ConsentModal {
@@ -77,6 +85,7 @@ export namespace VanillaCookieConsent {
     accept_all_btn?: string;
     reject_all_btn?: string;
     save_settings_btn?: string;
+    cookie_table_headers?: Record<string, string>[];
     blocks?: ModalBlock[];
   }
 


### PR DESCRIPTION
Backported from https://github.com/orestbida/cookieconsent/blob/v2.9/types/types.d.ts .