### PR TITLE
Add Croatian and Slovenian translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,8 +273,8 @@ initLmcCookieConsentManager( // when loaded as a module, these options are passe
 ### Supported languages
 
 Translation of the user interface is provided in the following languages:
-Czech (`cs`), German (`de`), English (`en`), Hungarian (`hu`), Polish (`pl`), Russian (`ru`), Slovak (`sk`)
-and Ukrainian (`uk`).
+Czech (`cs`), German (`de`), English (`en`), Croatian (`hr`), Hungarian (`hu`), Polish (`pl`), Russian (`ru`),
+Slovak (`sk`) and Ukrainian (`uk`).
 
 [👀 See example of each language version][examples-languages]
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ initLmcCookieConsentManager( // when loaded as a module, these options are passe
 
 Translation of the user interface is provided in the following languages:
 Czech (`cs`), German (`de`), English (`en`), Croatian (`hr`), Hungarian (`hu`), Polish (`pl`), Russian (`ru`),
-Slovak (`sk`) and Ukrainian (`uk`).
+Slovak (`sk`), Slovenian (`sl`) and Ukrainian (`uk`).
 
 [👀 See example of each language version][examples-languages]
 

--- a/examples/languages.html
+++ b/examples/languages.html
@@ -111,6 +111,10 @@
                     <label class="form-check-label" for="lang-select-en">English</label>
                 </div>
                 <div class="form-check">
+                    <input type="radio" class="form-check-input" id="lang-select-hr" value="hr" autocomplete="off" name="lang-select" onclick="toggleLanguage();">
+                    <label class="form-check-label" for="lang-select-hr">Croatian</label>
+                </div>
+                <div class="form-check">
                     <input type="radio" class="form-check-input" id="lang-select-hu" value="hu" autocomplete="off" name="lang-select" onclick="toggleLanguage();">
                     <label class="form-check-label" for="lang-select-hu">Hungarian</label>
                 </div>

--- a/examples/languages.html
+++ b/examples/languages.html
@@ -131,6 +131,10 @@
                     <label class="form-check-label" for="lang-select-sk">Slovak</label>
                 </div>
                 <div class="form-check">
+                    <input type="radio" class="form-check-input" id="lang-select-sl" value="sl" autocomplete="off" name="lang-select" onclick="toggleLanguage();">
+                    <label class="form-check-label" for="lang-select-sl">Slovenian</label>
+                </div>
+                <div class="form-check">
                     <input type="radio" class="form-check-input" id="lang-select-uk" value="uk" autocomplete="off" name="lang-select" onclick="toggleLanguage();">
                     <label class="form-check-label" for="lang-select-uk">Ukrainian</label>
                 </div>

--- a/src/LmcCookieConsentManager.ts
+++ b/src/LmcCookieConsentManager.ts
@@ -3,6 +3,7 @@ import { nanoid } from 'nanoid';
 import { config as configCs } from './languages/cs';
 import { config as configDe } from './languages/de';
 import { config as configEn } from './languages/en';
+import { config as configHr } from './languages/hr';
 import { config as configHu } from './languages/hu';
 import { config as configPl } from './languages/pl';
 import { config as configRu } from './languages/ru';
@@ -87,6 +88,7 @@ const LmcCookieConsentManager: CookieConsentManager = (serviceName, args) => {
     cs: configCs({ companyNames, ...translationOverrides.cs }, secondaryButtonMode),
     de: configDe({ companyNames, ...translationOverrides.de }, secondaryButtonMode),
     en: configEn({ companyNames, ...translationOverrides.en }, secondaryButtonMode),
+    hr: configHr({ companyNames, ...translationOverrides.hr }, secondaryButtonMode),
     hu: configHu({ companyNames, ...translationOverrides.hu }, secondaryButtonMode),
     pl: configPl({ companyNames, ...translationOverrides.pl }, secondaryButtonMode),
     ru: configRu({ companyNames, ...translationOverrides.ru }, secondaryButtonMode),

--- a/src/LmcCookieConsentManager.ts
+++ b/src/LmcCookieConsentManager.ts
@@ -8,6 +8,7 @@ import { config as configHu } from './languages/hu';
 import { config as configPl } from './languages/pl';
 import { config as configRu } from './languages/ru';
 import { config as configSk } from './languages/sk';
+import { config as configSl } from './languages/sl';
 import { config as configUk } from './languages/uk';
 import submitConsent from './consentCollector';
 import {
@@ -93,6 +94,7 @@ const LmcCookieConsentManager: CookieConsentManager = (serviceName, args) => {
     pl: configPl({ companyNames, ...translationOverrides.pl }, secondaryButtonMode),
     ru: configRu({ companyNames, ...translationOverrides.ru }, secondaryButtonMode),
     sk: configSk({ companyNames, ...translationOverrides.sk }, secondaryButtonMode),
+    sl: configSl({ companyNames, ...translationOverrides.sl }, secondaryButtonMode),
     uk: configUk({ companyNames, ...translationOverrides.uk }, secondaryButtonMode),
   };
 

--- a/src/languages/__tests__/__snapshots__/langConfig.test.ts.snap
+++ b/src/languages/__tests__/__snapshots__/langConfig.test.ts.snap
@@ -506,6 +506,180 @@ You can find more information about what cookies are and how we work with them o
 }
 `;
 
+exports[`config hr should return localization object for acceptNecessary button mode 1`] = `
+{
+  "consent_modal": {
+    "description": "
+      <p>Boljim razumijevanjem onoga što vas zanima, pokazat ćemo vam relevantniji sadržaj.</p>
+      <p>
+        Klikom na gumb „Prihvati sve“, dajete
+        test1, test2 i test3
+        privolu za upotrebu kolačića za personalizaciju, analitiku i ciljani marketing..
+        Možete prilagoditi upotrebu kolačića u svojim <strong><a href="" data-cc="c-settings">prilagođenim postavkama</a></strong>.
+      </p>",
+    "primary_btn": {
+      "role": "accept_all",
+      "text": "Prihvati sve",
+    },
+    "secondary_btn": {
+      "role": "accept_necessary",
+      "text": "Prihvati nužno",
+    },
+    "title": "Kolačići čine našu stranicu još boljom",
+  },
+  "settings_modal": {
+    "accept_all_btn": "Prihvati sve",
+    "blocks": [
+      {
+        "description": "Ako želite maksimalno iskoristiti našu web stranicu, najbolje je dopustiti sve vrste kolačića.
+Više informacija o tome što su kolačići i kako s njima radimo možete pronaći na stranici
+              <a href="https://www.almacareer.com/gdpr" target="_blank">Pravila privatnosti</a>.",
+      },
+      {
+        "description": "Ovi kolačići su ključni za pravilno funkcioniranje naše web stranice i stoga ih nije moguće onemogućiti.
+          Bez njih nije moguće prikazati sadržaj ili se prijaviti na našu web stranicu.",
+        "title": "Tehnički nužni kolačići",
+        "toggle": {
+          "enabled": true,
+          "readonly": true,
+          "value": "necessary",
+        },
+      },
+      {
+        "description": "Ovi nam pomažu pratiti koliko ljudi posjećuje našu web stranicu i kako je koriste.
+          Te informacije nam omogućuju kontinuirano poboljšavanje web stranice i drugih usluga.",
+        "title": "Analitički kolačići",
+        "toggle": {
+          "enabled": false,
+          "readonly": false,
+          "value": "analytics",
+        },
+      },
+      {
+        "description": "Naša web stranica djeluje još učinkovitije i bolje zahvaljujući ovim kolačićima.
+          Na primjer, omogućuju nam korištenje usluge razgovora i brzo i jednostavno odgovaranje na vaša pitanja.",
+        "title": "Funkcionalni kolačići",
+        "toggle": {
+          "enabled": false,
+          "readonly": false,
+          "value": "functionality",
+        },
+      },
+      {
+        "description": "Ovi kolačići nam pomažu mjeriti učinkovitost našeg oglašavanja i ciljanih ponuda usluga.
+          Marketing kolačići omogućuju nam donošenje vijesti koje bi vas mogle zanimati na internetu.",
+        "title": "Marketing kolačići",
+        "toggle": {
+          "enabled": false,
+          "readonly": false,
+          "value": "ad",
+        },
+      },
+      {
+        "description": "Naše usluge bolje funkcioniraju ako ih možemo prilagoditi određenim korisnicima.
+          Dopuštanjem personalizacijskih kolačića povećavate šanse da pronađete sadržaj koji želite.",
+        "title": "Personalizacijski kolačići",
+        "toggle": {
+          "enabled": false,
+          "readonly": false,
+          "value": "personalization",
+        },
+      },
+    ],
+    "reject_all_btn": "Prihvati nužno",
+    "save_settings_btn": "Spremi postavke",
+    "title": "Prilagođene postavke kolačića",
+  },
+}
+`;
+
+exports[`config hr should return localization object for showSettings button mode 1`] = `
+{
+  "consent_modal": {
+    "description": "
+      <p>Boljim razumijevanjem onoga što vas zanima, pokazat ćemo vam relevantniji sadržaj.</p>
+      <p>
+        Klikom na gumb „Prihvati sve“, dajete
+        test1, test2 i test3
+        privolu za upotrebu kolačića za personalizaciju, analitiku i ciljani marketing..
+        
+      </p>",
+    "primary_btn": {
+      "role": "accept_all",
+      "text": "Prihvati sve",
+    },
+    "secondary_btn": {
+      "role": "settings",
+      "text": "Prilagođene postavke",
+    },
+    "title": "Kolačići čine našu stranicu još boljom",
+  },
+  "settings_modal": {
+    "accept_all_btn": "Prihvati sve",
+    "blocks": [
+      {
+        "description": "Ako želite maksimalno iskoristiti našu web stranicu, najbolje je dopustiti sve vrste kolačića.
+Više informacija o tome što su kolačići i kako s njima radimo možete pronaći na stranici
+              <a href="https://www.almacareer.com/gdpr" target="_blank">Pravila privatnosti</a>.",
+      },
+      {
+        "description": "Ovi kolačići su ključni za pravilno funkcioniranje naše web stranice i stoga ih nije moguće onemogućiti.
+          Bez njih nije moguće prikazati sadržaj ili se prijaviti na našu web stranicu.",
+        "title": "Tehnički nužni kolačići",
+        "toggle": {
+          "enabled": true,
+          "readonly": true,
+          "value": "necessary",
+        },
+      },
+      {
+        "description": "Ovi nam pomažu pratiti koliko ljudi posjećuje našu web stranicu i kako je koriste.
+          Te informacije nam omogućuju kontinuirano poboljšavanje web stranice i drugih usluga.",
+        "title": "Analitički kolačići",
+        "toggle": {
+          "enabled": false,
+          "readonly": false,
+          "value": "analytics",
+        },
+      },
+      {
+        "description": "Naša web stranica djeluje još učinkovitije i bolje zahvaljujući ovim kolačićima.
+          Na primjer, omogućuju nam korištenje usluge razgovora i brzo i jednostavno odgovaranje na vaša pitanja.",
+        "title": "Funkcionalni kolačići",
+        "toggle": {
+          "enabled": false,
+          "readonly": false,
+          "value": "functionality",
+        },
+      },
+      {
+        "description": "Ovi kolačići nam pomažu mjeriti učinkovitost našeg oglašavanja i ciljanih ponuda usluga.
+          Marketing kolačići omogućuju nam donošenje vijesti koje bi vas mogle zanimati na internetu.",
+        "title": "Marketing kolačići",
+        "toggle": {
+          "enabled": false,
+          "readonly": false,
+          "value": "ad",
+        },
+      },
+      {
+        "description": "Naše usluge bolje funkcioniraju ako ih možemo prilagoditi određenim korisnicima.
+          Dopuštanjem personalizacijskih kolačića povećavate šanse da pronađete sadržaj koji želite.",
+        "title": "Personalizacijski kolačići",
+        "toggle": {
+          "enabled": false,
+          "readonly": false,
+          "value": "personalization",
+        },
+      },
+    ],
+    "reject_all_btn": "Prihvati nužno",
+    "save_settings_btn": "Spremi postavke",
+    "title": "Prilagođene postavke kolačića",
+  },
+}
+`;
+
 exports[`config hu should return localization object for acceptNecessary button mode 1`] = `
 {
   "consent_modal": {

--- a/src/languages/__tests__/__snapshots__/langConfig.test.ts.snap
+++ b/src/languages/__tests__/__snapshots__/langConfig.test.ts.snap
@@ -1344,6 +1344,180 @@ exports[`config sk should return localization object for showSettings button mod
 }
 `;
 
+exports[`config sl should return localization object for acceptNecessary button mode 1`] = `
+{
+  "consent_modal": {
+    "description": "
+      <p>Z boljšim razumevanjem, kaj vas zanima, vam bomo prikazali bolj relevantno vsebino.</p>
+      <p>
+        S klikom na gumb „Sprejmi vse“ dajete soglasje podjetjem
+        test1, test2 in test3
+        za uporabo piškotkov za personalizacijo, analitiko in ciljno oglaševanje.
+        Uporabo piškotkov lahko prilagodite v <strong><a href="" data-cc="c-settings">svojih nastavitvah</a></strong>.
+      </p>",
+    "primary_btn": {
+      "role": "accept_all",
+      "text": "Sprejmi vse",
+    },
+    "secondary_btn": {
+      "role": "accept_necessary",
+      "text": "Sprejmi samo nujne",
+    },
+    "title": "Piškotki izboljšujejo našo spletno stran",
+  },
+  "settings_modal": {
+    "accept_all_btn": "Sprejmi vse",
+    "blocks": [
+      {
+        "description": "Če želite najbolje izkoristiti našo spletno stran, je najbolje, da dovolite vse vrste piškotkov.
+Več informacij o tem, kaj so piškotki in kako z njimi upravljamo, najdete na strani
+              <a href="https://www.almacareer.com/gdpr" target="_blank">Pravilnik o zasebnosti</a>.",
+      },
+      {
+        "description": "Ti piškotki so bistveni za pravilno delovanje naše spletne strani in jih ni mogoče izklopiti.
+          Brez njih ne bi bilo mogoče prikazati vsebine ali se prijaviti na našo spletno stran.",
+        "title": "Tehnično nujni piškotki",
+        "toggle": {
+          "enabled": true,
+          "readonly": true,
+          "value": "necessary",
+        },
+      },
+      {
+        "description": "Ti nam pomagajo spremljati, koliko ljudi obišče našo spletno stran in kako jo uporabljajo.
+          Te informacije nam omogočajo nenehno izboljševanje spletne strani in drugih storitev.",
+        "title": "Analitični piškotki",
+        "toggle": {
+          "enabled": false,
+          "readonly": false,
+          "value": "analytics",
+        },
+      },
+      {
+        "description": "Naša spletna stran je še učinkovitejša in bolje deluje zaradi teh piškotkov.
+          Na primer, omogočajo nam uporabo klepetalne storitve in hitro ter enostavno odgovarjanje na vaša vprašanja.",
+        "title": "Funkcionalni piškotki",
+        "toggle": {
+          "enabled": false,
+          "readonly": false,
+          "value": "functionality",
+        },
+      },
+      {
+        "description": "Ti piškotki nam pomagajo meriti učinkovitost našega oglaševanja in ciljnih ponudb storitev.
+          Trženjski piškotki nam omogočajo, da vam na internetu prinašamo novice, ki vas morda zanimajo.",
+        "title": "Trženjski piškotki",
+        "toggle": {
+          "enabled": false,
+          "readonly": false,
+          "value": "ad",
+        },
+      },
+      {
+        "description": "Naše storitve bolje delujejo, če jih lahko prilagodimo določenim uporabnikom.
+          Z dovoljenjem piškotkov za prilagajanje povečate možnosti, da najdete vsebino, ki jo želite.",
+        "title": "Piškotki za prilagajanje",
+        "toggle": {
+          "enabled": false,
+          "readonly": false,
+          "value": "personalization",
+        },
+      },
+    ],
+    "reject_all_btn": "Sprejmi samo nujne",
+    "save_settings_btn": "Shrani nastavitve",
+    "title": "Prilagojene nastavitve piškotkov",
+  },
+}
+`;
+
+exports[`config sl should return localization object for showSettings button mode 1`] = `
+{
+  "consent_modal": {
+    "description": "
+      <p>Z boljšim razumevanjem, kaj vas zanima, vam bomo prikazali bolj relevantno vsebino.</p>
+      <p>
+        S klikom na gumb „Sprejmi vse“ dajete soglasje podjetjem
+        test1, test2 in test3
+        za uporabo piškotkov za personalizacijo, analitiko in ciljno oglaševanje.
+        
+      </p>",
+    "primary_btn": {
+      "role": "accept_all",
+      "text": "Sprejmi vse",
+    },
+    "secondary_btn": {
+      "role": "settings",
+      "text": "Shrani nastavitve",
+    },
+    "title": "Piškotki izboljšujejo našo spletno stran",
+  },
+  "settings_modal": {
+    "accept_all_btn": "Sprejmi vse",
+    "blocks": [
+      {
+        "description": "Če želite najbolje izkoristiti našo spletno stran, je najbolje, da dovolite vse vrste piškotkov.
+Več informacij o tem, kaj so piškotki in kako z njimi upravljamo, najdete na strani
+              <a href="https://www.almacareer.com/gdpr" target="_blank">Pravilnik o zasebnosti</a>.",
+      },
+      {
+        "description": "Ti piškotki so bistveni za pravilno delovanje naše spletne strani in jih ni mogoče izklopiti.
+          Brez njih ne bi bilo mogoče prikazati vsebine ali se prijaviti na našo spletno stran.",
+        "title": "Tehnično nujni piškotki",
+        "toggle": {
+          "enabled": true,
+          "readonly": true,
+          "value": "necessary",
+        },
+      },
+      {
+        "description": "Ti nam pomagajo spremljati, koliko ljudi obišče našo spletno stran in kako jo uporabljajo.
+          Te informacije nam omogočajo nenehno izboljševanje spletne strani in drugih storitev.",
+        "title": "Analitični piškotki",
+        "toggle": {
+          "enabled": false,
+          "readonly": false,
+          "value": "analytics",
+        },
+      },
+      {
+        "description": "Naša spletna stran je še učinkovitejša in bolje deluje zaradi teh piškotkov.
+          Na primer, omogočajo nam uporabo klepetalne storitve in hitro ter enostavno odgovarjanje na vaša vprašanja.",
+        "title": "Funkcionalni piškotki",
+        "toggle": {
+          "enabled": false,
+          "readonly": false,
+          "value": "functionality",
+        },
+      },
+      {
+        "description": "Ti piškotki nam pomagajo meriti učinkovitost našega oglaševanja in ciljnih ponudb storitev.
+          Trženjski piškotki nam omogočajo, da vam na internetu prinašamo novice, ki vas morda zanimajo.",
+        "title": "Trženjski piškotki",
+        "toggle": {
+          "enabled": false,
+          "readonly": false,
+          "value": "ad",
+        },
+      },
+      {
+        "description": "Naše storitve bolje delujejo, če jih lahko prilagodimo določenim uporabnikom.
+          Z dovoljenjem piškotkov za prilagajanje povečate možnosti, da najdete vsebino, ki jo želite.",
+        "title": "Piškotki za prilagajanje",
+        "toggle": {
+          "enabled": false,
+          "readonly": false,
+          "value": "personalization",
+        },
+      },
+    ],
+    "reject_all_btn": "Sprejmi samo nujne",
+    "save_settings_btn": "Shrani nastavitve",
+    "title": "Prilagojene nastavitve piškotkov",
+  },
+}
+`;
+
 exports[`config uk should return localization object for acceptNecessary button mode 1`] = `
 {
   "consent_modal": {

--- a/src/languages/__tests__/langConfig.test.ts
+++ b/src/languages/__tests__/langConfig.test.ts
@@ -6,6 +6,7 @@ import { config as configHu } from '../hu';
 import { config as configPl } from '../pl';
 import { config as configRu } from '../ru';
 import { config as configSk } from '../sk';
+import { config as configSl } from '../sl';
 import { config as configUk } from '../uk';
 import { SecondaryButtonMode } from '../../constants/SecondaryButtonMode';
 
@@ -18,6 +19,7 @@ describe.each([
   ['pl', configPl],
   ['ru', configRu],
   ['sk', configSk],
+  ['sl', configSl],
   ['uk', configUk],
 ])('config %s', (name, config) => {
   it('should return localization object for acceptNecessary button mode', () => {

--- a/src/languages/__tests__/langConfig.test.ts
+++ b/src/languages/__tests__/langConfig.test.ts
@@ -1,6 +1,7 @@
 import { config as configCs } from '../cs';
 import { config as configDe } from '../de';
 import { config as configEn } from '../en';
+import { config as configHr } from '../hr';
 import { config as configHu } from '../hu';
 import { config as configPl } from '../pl';
 import { config as configRu } from '../ru';
@@ -13,6 +14,7 @@ describe.each([
   ['de', configDe],
   ['en', configEn],
   ['hu', configHu],
+  ['hr', configHr],
   ['pl', configPl],
   ['ru', configRu],
   ['sk', configSk],

--- a/src/languages/hr.ts
+++ b/src/languages/hr.ts
@@ -1,0 +1,120 @@
+import {
+  addSeparators,
+  assembleDescriptionIntro,
+  assembleSecondaryButton,
+  isSettingsButtonNotShown,
+  pluralize,
+  legalizeAlmaCareer,
+} from '../utils';
+import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
+import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
+
+const extra = {
+  and: 'i',
+  legalName: 'tvrtkama iz poslovne grupacije Alma Career',
+};
+
+/**
+ * @param {ExtraMessages} [extraMessages] - Object with extra messages
+ * @param {SecondaryButtonMode} [secondaryButtonMode] - Which secondary button should be shown
+ * @returns {VanillaCookieConsent.Languages} Object with translated messages
+ */
+export const config = (
+  extraMessages: ExtraMessages,
+  secondaryButtonMode: Values<typeof SecondaryButtonMode>,
+): VanillaCookieConsent.Languages => {
+  const lang = { ...extra, ...extraMessages };
+
+  return {
+    consent_modal: {
+      title: lang.consentTitle ?? 'Kolačići čine našu stranicu još boljom',
+      description: `
+      ${assembleDescriptionIntro(
+        'Boljim razumijevanjem onoga što vas zanima, pokazat ćemo vam relevantniji sadržaj.',
+        lang.descriptionIntro,
+      )}
+      <p>
+        Klikom na gumb „Prihvati sve“, dajete
+        ${addSeparators(legalizeAlmaCareer(lang.companyNames, lang.legalName), lang.and)}
+        privolu za upotrebu kolačića za personalizaciju, analitiku i ciljani marketing..
+        ${
+          isSettingsButtonNotShown(secondaryButtonMode)
+            ? `Možete prilagoditi upotrebu kolačića u svojim <strong><a href="" data-cc="c-settings">prilagođenim postavkama</a></strong>.`
+            : ''
+        }
+      </p>`,
+      primary_btn: {
+        text: 'Prihvati sve',
+        role: VanillaCookieConsent.PrimaryButtonRole.ACCEPT_ALL,
+      },
+      secondary_btn: assembleSecondaryButton(secondaryButtonMode, 'Prihvati nužno', 'Prilagođene postavke'),
+    },
+    settings_modal: {
+      title: 'Prilagođene postavke kolačića',
+      accept_all_btn: 'Prihvati sve',
+      reject_all_btn: 'Prihvati nužno',
+      save_settings_btn: 'Spremi postavke',
+      blocks: [
+        {
+          description:
+            `Ako želite maksimalno iskoristiti našu web stranicu, najbolje je dopustiti sve vrste kolačića.\n` +
+            (lang.settingsModalMoreInfo ??
+              `Više informacija o tome što su kolačići i kako s njima radimo možete pronaći na stranici
+              <a href="https://www.almacareer.com/gdpr" target="_blank">Pravila privatnosti</a>.`),
+        },
+        {
+          title: 'Tehnički nužni kolačići',
+          description: `Ovi kolačići su ključni za pravilno funkcioniranje naše web stranice i stoga ih nije moguće onemogućiti.
+          Bez njih nije moguće prikazati sadržaj ili se prijaviti na našu web stranicu.`,
+          toggle: {
+            value: CookieConsentCategory.NECESSARY,
+            enabled: true,
+            readonly: true,
+          },
+        },
+        {
+          title: 'Analitički kolačići',
+          description: `Ovi nam pomažu pratiti koliko ljudi posjećuje našu web stranicu i kako je koriste.
+          Te informacije nam omogućuju kontinuirano poboljšavanje web stranice i drugih usluga.`,
+          toggle: {
+            value: CookieConsentCategory.ANALYTICS,
+            enabled: false,
+            readonly: false,
+          },
+        },
+        {
+          title: 'Funkcionalni kolačići',
+          description: `Naša web stranica djeluje još učinkovitije i bolje zahvaljujući ovim kolačićima.
+          Na primjer, omogućuju nam korištenje usluge razgovora i brzo i jednostavno odgovaranje na vaša pitanja.`,
+          toggle: {
+            value: CookieConsentCategory.FUNCTIONALITY,
+            enabled: false,
+            readonly: false,
+          },
+        },
+        {
+          title: 'Marketing kolačići',
+          description: `Ovi kolačići nam pomažu mjeriti učinkovitost našeg oglašavanja i ciljanih ponuda usluga.
+          Marketing kolačići omogućuju nam donošenje vijesti koje bi vas mogle zanimati na internetu.`,
+          toggle: {
+            value: CookieConsentCategory.AD,
+            enabled: false,
+            readonly: false,
+          },
+        },
+        {
+          title: 'Personalizacijski kolačići',
+          description: `Naše usluge bolje funkcioniraju ako ih možemo prilagoditi određenim korisnicima.
+          Dopuštanjem personalizacijskih kolačića povećavate šanse da pronađete sadržaj koji želite.`,
+          toggle: {
+            value: CookieConsentCategory.PERSONALIZATION,
+            enabled: false,
+            readonly: false,
+          },
+        },
+      ],
+    },
+  };
+};
+
+export default config;

--- a/src/languages/sl.ts
+++ b/src/languages/sl.ts
@@ -1,0 +1,120 @@
+import {
+  addSeparators,
+  assembleDescriptionIntro,
+  assembleSecondaryButton,
+  isSettingsButtonNotShown,
+  pluralize,
+  legalizeAlmaCareer,
+} from '../utils';
+import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
+import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
+
+const extra = {
+  and: 'in',
+  legalName: 'iz poslovne skupine Alma Career',
+};
+
+/**
+ * @param {ExtraMessages} [extraMessages] - Object with extra messages
+ * @param {SecondaryButtonMode} [secondaryButtonMode] - Which secondary button should be shown
+ * @returns {VanillaCookieConsent.Languages} Object with translated messages
+ */
+export const config = (
+  extraMessages: ExtraMessages,
+  secondaryButtonMode: Values<typeof SecondaryButtonMode>,
+): VanillaCookieConsent.Languages => {
+  const lang = { ...extra, ...extraMessages };
+
+  return {
+    consent_modal: {
+      title: lang.consentTitle ?? 'Piškotki izboljšujejo našo spletno stran',
+      description: `
+      ${assembleDescriptionIntro(
+        'Z boljšim razumevanjem, kaj vas zanima, vam bomo prikazali bolj relevantno vsebino.',
+        lang.descriptionIntro,
+      )}
+      <p>
+        S klikom na gumb „Sprejmi vse“ dajete soglasje podjetjem
+        ${addSeparators(legalizeAlmaCareer(lang.companyNames, lang.legalName), lang.and)}
+        za uporabo piškotkov za personalizacijo, analitiko in ciljno oglaševanje.
+        ${
+          isSettingsButtonNotShown(secondaryButtonMode)
+            ? `Uporabo piškotkov lahko prilagodite v <strong><a href="" data-cc="c-settings">svojih nastavitvah</a></strong>.`
+            : ''
+        }
+      </p>`,
+      primary_btn: {
+        text: 'Sprejmi vse',
+        role: VanillaCookieConsent.PrimaryButtonRole.ACCEPT_ALL,
+      },
+      secondary_btn: assembleSecondaryButton(secondaryButtonMode, 'Sprejmi samo nujne', 'Shrani nastavitve'),
+    },
+    settings_modal: {
+      title: 'Prilagojene nastavitve piškotkov',
+      accept_all_btn: 'Sprejmi vse',
+      reject_all_btn: 'Sprejmi samo nujne',
+      save_settings_btn: 'Shrani nastavitve',
+      blocks: [
+        {
+          description:
+            `Če želite najbolje izkoristiti našo spletno stran, je najbolje, da dovolite vse vrste piškotkov.\n` +
+            (lang.settingsModalMoreInfo ??
+              `Več informacij o tem, kaj so piškotki in kako z njimi upravljamo, najdete na strani
+              <a href="https://www.almacareer.com/gdpr" target="_blank">Pravilnik o zasebnosti</a>.`),
+        },
+        {
+          title: 'Tehnično nujni piškotki',
+          description: `Ti piškotki so bistveni za pravilno delovanje naše spletne strani in jih ni mogoče izklopiti.
+          Brez njih ne bi bilo mogoče prikazati vsebine ali se prijaviti na našo spletno stran.`,
+          toggle: {
+            value: CookieConsentCategory.NECESSARY,
+            enabled: true,
+            readonly: true,
+          },
+        },
+        {
+          title: 'Analitični piškotki',
+          description: `Ti nam pomagajo spremljati, koliko ljudi obišče našo spletno stran in kako jo uporabljajo.
+          Te informacije nam omogočajo nenehno izboljševanje spletne strani in drugih storitev.`,
+          toggle: {
+            value: CookieConsentCategory.ANALYTICS,
+            enabled: false,
+            readonly: false,
+          },
+        },
+        {
+          title: 'Funkcionalni piškotki',
+          description: `Naša spletna stran je še učinkovitejša in bolje deluje zaradi teh piškotkov.
+          Na primer, omogočajo nam uporabo klepetalne storitve in hitro ter enostavno odgovarjanje na vaša vprašanja.`,
+          toggle: {
+            value: CookieConsentCategory.FUNCTIONALITY,
+            enabled: false,
+            readonly: false,
+          },
+        },
+        {
+          title: 'Trženjski piškotki',
+          description: `Ti piškotki nam pomagajo meriti učinkovitost našega oglaševanja in ciljnih ponudb storitev.
+          Trženjski piškotki nam omogočajo, da vam na internetu prinašamo novice, ki vas morda zanimajo.`,
+          toggle: {
+            value: CookieConsentCategory.AD,
+            enabled: false,
+            readonly: false,
+          },
+        },
+        {
+          title: 'Piškotki za prilagajanje',
+          description: `Naše storitve bolje delujejo, če jih lahko prilagodimo določenim uporabnikom.
+          Z dovoljenjem piškotkov za prilagajanje povečate možnosti, da najdete vsebino, ki jo želite.`,
+          toggle: {
+            value: CookieConsentCategory.PERSONALIZATION,
+            enabled: false,
+            readonly: false,
+          },
+        },
+      ],
+    },
+  };
+};
+
+export default config;


### PR DESCRIPTION
Still WIP, as we are missing some translations, specifically these: (Czech translation used as a placeholder)

```
and: 'i',
company: 'společnosti',
companies: 'společnostem',
legalName: 'Alma Career a společnostem z její obchodní skupiny',
```