### PR TITLE
Docs: Update links to orestbida library documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,9 +486,9 @@ Distributed under the MIT License. See [LICENSE](https://github.com/lmc-eu/cooki
 for more information.
 
 [cookie consent]: https://github.com/orestbida/cookieconsent
-[cookie consent api]: https://github.com/orestbida/cookieconsent#api-methods
-[cookie consent third party]: https://github.com/orestbida/cookieconsent#how-to-blockmanage-scripts
-[cookie consent options]: https://github.com/orestbida/cookieconsent#all-configuration-options
+[cookie consent api]: https://github.com/orestbida/cookieconsent/tree/v2.9?tab=readme-ov-file#api
+[cookie consent third party]: https://github.com/orestbida/cookieconsent/tree/v2.9?tab=readme-ov-file#how-to-blockmanage-scripts
+[cookie consent options]: https://github.com/orestbida/cookieconsent/tree/v2.9?tab=readme-ov-file#configuration-options
 [orest bida]: https://github.com/orestbida
 [spirit design system]: https://github.com/lmc-eu/spirit-design-system
 [spirit design tokens]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/design-tokens

--- a/examples/configuration.html
+++ b/examples/configuration.html
@@ -159,7 +159,7 @@
         secondaryButtonMode: 'showSettings', // use "Show settings" as the secondary button instead of default "Accept only necessary"
         companyNames: ['Alma Career', 'Some Other Company', 'ACME'], // define custom company names to be shown in the consent text
         consentCollectorApiUrl: 'https://ccm.lmc.cz/local-data-acceptation-data-entries?Spot=(public,demo)', // override default URL for demo purposes; do not set custom consentCollectorApiUrl unless you have been explicitly guided to do so!
-        config: { // override default config of the underlying library, see https://github.com/orestbida/cookieconsent#all-available-options
+        config: { // override default config of the underlying library, see https://github.com/orestbida/cookieconsent/tree/v2.9?tab=readme-ov-file#configuration-options
           delay: 500, // show cookie consent banner after 500ms
           page_scripts: false, // disable third-party script management, see https://github.com/lmc-eu/cookie-consent-manager#third-party-scripts-loaded-via-script
           cookie_necessary_only_expiration: 30, // expire consent after 30 days instead of default 60 (when only necessary accepted)


### PR DESCRIPTION
To keep them working as we still depends on older version 2.9.