### PR TITLE
Refactor block assembly

### DIFF
--- a/src/LmcCookieConsentManager.ts
+++ b/src/LmcCookieConsentManager.ts
@@ -17,9 +17,9 @@ import {
   OnAcceptCallback,
   OnChangeCallback,
   CookieConsentCategoryValues,
+  VanillaCookieConsent,
 } from './types';
 import { CookieConsentCategory, DisplayMode, SecondaryButtonMode } from './constants';
-import { VanillaCookieConsent } from './types/vanilla-cookieconsent';
 
 /* eslint-disable-next-line no-unused-vars */
 const noopAcceptCallback: OnAcceptCallback = (cookieConsent) => {};

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -5,8 +5,13 @@ import {
   isSettingsButtonNotShown,
   legalizeAlmaCareer,
   pluralize,
+  assembleCategoryNecessary,
+  assembleCategoryPersonalization,
+  assembleCategoryFunctionality,
+  assembleCategoryAnalytics,
+  assembleCategoryAd,
 } from '../utils';
-import { SecondaryButtonMode } from '../constants';
+import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
 
 describe('utils', () => {
   describe('addSeparators', () => {
@@ -92,6 +97,56 @@ describe('utils', () => {
 
     it('should be false for SHOW_SETTINGS mode', () => {
       expect(isSettingsButtonNotShown(SecondaryButtonMode.SHOW_SETTINGS)).toBe(false);
+    });
+  });
+
+  describe('assembleCategoryNecessary', () => {
+    it('should assemble modal category block', () => {
+      expect(assembleCategoryNecessary('title', 'description')).toEqual({
+        title: 'title',
+        description: 'description',
+        toggle: { value: CookieConsentCategory.NECESSARY, enabled: true, readonly: true },
+      });
+    });
+  });
+
+  describe('assembleCategoryAd', () => {
+    it('should assemble modal category block', () => {
+      expect(assembleCategoryAd('title', 'description')).toEqual({
+        title: 'title',
+        description: 'description',
+        toggle: { value: CookieConsentCategory.AD, enabled: false, readonly: false },
+      });
+    });
+  });
+
+  describe('assembleCategoryAnalytics', () => {
+    it('should assemble modal category block', () => {
+      expect(assembleCategoryAnalytics('title', 'description')).toEqual({
+        title: 'title',
+        description: 'description',
+        toggle: { value: CookieConsentCategory.ANALYTICS, enabled: false, readonly: false },
+      });
+    });
+  });
+
+  describe('assembleCategoryFunctionality', () => {
+    it('should assemble modal category block', () => {
+      expect(assembleCategoryFunctionality('title', 'description')).toEqual({
+        title: 'title',
+        description: 'description',
+        toggle: { value: CookieConsentCategory.FUNCTIONALITY, enabled: false, readonly: false },
+      });
+    });
+  });
+
+  describe('assembleCategoryPersonalization', () => {
+    it('should assemble modal category block', () => {
+      expect(assembleCategoryPersonalization('title', 'description')).toEqual({
+        title: 'title',
+        description: 'description',
+        toggle: { value: CookieConsentCategory.PERSONALIZATION, enabled: false, readonly: false },
+      });
     });
   });
 });

--- a/src/consentCollector.ts
+++ b/src/consentCollector.ts
@@ -1,5 +1,4 @@
-import { CookieConsentCategoryValues } from './types';
-import { VanillaCookieConsent } from './types/vanilla-cookieconsent';
+import { CookieConsentCategoryValues, VanillaCookieConsent } from './types';
 
 /**
  * Submit information about consent level given by the user.

--- a/src/languages/__tests__/__snapshots__/langConfig.test.ts.snap
+++ b/src/languages/__tests__/__snapshots__/langConfig.test.ts.snap
@@ -31,8 +31,7 @@ Další informace o tom, co jsou cookies a jak s nimi pracujeme, najdete
               v <a href="https://www.almacareer.com/gdpr" target="_blank">Zásadách cookies</a>.",
       },
       {
-        "description": "Tyto Cookies jsou pro správné fungování našeho webu nezbytné, proto není možné je vypnout.
-          Bez nich by na našich stránkách např. nešel zobrazit žádný obsah nebo by nefungovalo přihlášení.",
+        "description": "Tyto Cookies jsou pro správné fungování našeho webu nezbytné, proto není možné je vypnout. Bez nich by na našich stránkách např. nešel zobrazit žádný obsah nebo by nefungovalo přihlášení.",
         "title": "Technicky nezbytné Cookies",
         "toggle": {
           "enabled": true,
@@ -41,8 +40,7 @@ Další informace o tom, co jsou cookies a jak s nimi pracujeme, najdete
         },
       },
       {
-        "description": "Pomocí nich sledujeme, kolik lidí náš web navštěvuje a jak ho používají.
-          Díky tomu můžeme stránky a další služby neustále vylepšovat.",
+        "description": "Pomocí nich sledujeme, kolik lidí náš web navštěvuje a jak ho používají. Díky tomu můžeme stránky a další služby neustále vylepšovat.",
         "title": "Analytické Cookies",
         "toggle": {
           "enabled": false,
@@ -51,8 +49,7 @@ Další informace o tom, co jsou cookies a jak s nimi pracujeme, najdete
         },
       },
       {
-        "description": "Díky těmto Cookies jsou naše stránky ještě výkonnější a fungují lépe.
-          Například nám umožňují používat chat, abychom na vaše otázky mohli odpovídat rychle a jednoduše.",
+        "description": "Díky těmto Cookies jsou naše stránky ještě výkonnější a fungují lépe. Například nám umožňují používat chat, abychom na vaše otázky mohli odpovídat rychle a jednoduše.",
         "title": "Funkční Cookies",
         "toggle": {
           "enabled": false,
@@ -61,8 +58,7 @@ Další informace o tom, co jsou cookies a jak s nimi pracujeme, najdete
         },
       },
       {
-        "description": "S těmito Cookies můžeme měřit, jak efektivní je naše reklama a cílené nabídky našich služeb.
-          Marketingové Cookies nám umožní vás na Internetu upozornit na novinky, které vás můžou zajímat.",
+        "description": "S těmito Cookies můžeme měřit, jak efektivní je naše reklama a cílené nabídky našich služeb. Marketingové Cookies nám umožní vás na Internetu upozornit na novinky, které vás můžou zajímat.",
         "title": "Marketingové Cookies",
         "toggle": {
           "enabled": false,
@@ -71,8 +67,7 @@ Další informace o tom, co jsou cookies a jak s nimi pracujeme, najdete
         },
       },
       {
-        "description": "Naše služby fungují lépe, když je můžeme přizpůsobit na míru konkrétnímu uživateli.
-          Povolením Personalizačních cookies zvýšíte šanci, že najdete právě takový obsah, jaký hledáte.",
+        "description": "Naše služby fungují lépe, když je můžeme přizpůsobit na míru konkrétnímu uživateli. Povolením Personalizačních cookies zvýšíte šanci, že najdete právě takový obsah, jaký hledáte.",
         "title": "Personalizační Cookies",
         "toggle": {
           "enabled": false,
@@ -119,8 +114,7 @@ Další informace o tom, co jsou cookies a jak s nimi pracujeme, najdete
               v <a href="https://www.almacareer.com/gdpr" target="_blank">Zásadách cookies</a>.",
       },
       {
-        "description": "Tyto Cookies jsou pro správné fungování našeho webu nezbytné, proto není možné je vypnout.
-          Bez nich by na našich stránkách např. nešel zobrazit žádný obsah nebo by nefungovalo přihlášení.",
+        "description": "Tyto Cookies jsou pro správné fungování našeho webu nezbytné, proto není možné je vypnout. Bez nich by na našich stránkách např. nešel zobrazit žádný obsah nebo by nefungovalo přihlášení.",
         "title": "Technicky nezbytné Cookies",
         "toggle": {
           "enabled": true,
@@ -129,8 +123,7 @@ Další informace o tom, co jsou cookies a jak s nimi pracujeme, najdete
         },
       },
       {
-        "description": "Pomocí nich sledujeme, kolik lidí náš web navštěvuje a jak ho používají.
-          Díky tomu můžeme stránky a další služby neustále vylepšovat.",
+        "description": "Pomocí nich sledujeme, kolik lidí náš web navštěvuje a jak ho používají. Díky tomu můžeme stránky a další služby neustále vylepšovat.",
         "title": "Analytické Cookies",
         "toggle": {
           "enabled": false,
@@ -139,8 +132,7 @@ Další informace o tom, co jsou cookies a jak s nimi pracujeme, najdete
         },
       },
       {
-        "description": "Díky těmto Cookies jsou naše stránky ještě výkonnější a fungují lépe.
-          Například nám umožňují používat chat, abychom na vaše otázky mohli odpovídat rychle a jednoduše.",
+        "description": "Díky těmto Cookies jsou naše stránky ještě výkonnější a fungují lépe. Například nám umožňují používat chat, abychom na vaše otázky mohli odpovídat rychle a jednoduše.",
         "title": "Funkční Cookies",
         "toggle": {
           "enabled": false,
@@ -149,8 +141,7 @@ Další informace o tom, co jsou cookies a jak s nimi pracujeme, najdete
         },
       },
       {
-        "description": "S těmito Cookies můžeme měřit, jak efektivní je naše reklama a cílené nabídky našich služeb.
-          Marketingové Cookies nám umožní vás na Internetu upozornit na novinky, které vás můžou zajímat.",
+        "description": "S těmito Cookies můžeme měřit, jak efektivní je naše reklama a cílené nabídky našich služeb. Marketingové Cookies nám umožní vás na Internetu upozornit na novinky, které vás můžou zajímat.",
         "title": "Marketingové Cookies",
         "toggle": {
           "enabled": false,
@@ -159,8 +150,7 @@ Další informace o tom, co jsou cookies a jak s nimi pracujeme, najdete
         },
       },
       {
-        "description": "Naše služby fungují lépe, když je můžeme přizpůsobit na míru konkrétnímu uživateli.
-          Povolením Personalizačních cookies zvýšíte šanci, že najdete právě takový obsah, jaký hledáte.",
+        "description": "Naše služby fungují lépe, když je můžeme přizpůsobit na míru konkrétnímu uživateli. Povolením Personalizačních cookies zvýšíte šanci, že najdete právě takový obsah, jaký hledáte.",
         "title": "Personalizační Cookies",
         "toggle": {
           "enabled": false,
@@ -536,8 +526,7 @@ Više informacija o tome što su kolačići i kako s njima radimo možete pron
               <a href="https://www.almacareer.com/gdpr" target="_blank">Pravila privatnosti</a>.",
       },
       {
-        "description": "Ovi kolačići su ključni za pravilno funkcioniranje naše web stranice i stoga ih nije moguće onemogućiti.
-          Bez njih nije moguće prikazati sadržaj ili se prijaviti na našu web stranicu.",
+        "description": "Ovi kolačići su ključni za pravilno funkcioniranje naše web stranice i stoga ih nije moguće onemogućiti. Bez njih nije moguće prikazati sadržaj ili se prijaviti na našu web stranicu.",
         "title": "Tehnički nužni kolačići",
         "toggle": {
           "enabled": true,
@@ -546,8 +535,7 @@ Više informacija o tome što su kolačići i kako s njima radimo možete pron
         },
       },
       {
-        "description": "Ovi nam pomažu pratiti koliko ljudi posjećuje našu web stranicu i kako je koriste.
-          Te informacije nam omogućuju kontinuirano poboljšavanje web stranice i drugih usluga.",
+        "description": "Ovi nam pomažu pratiti koliko ljudi posjećuje našu web stranicu i kako je koriste. Te informacije nam omogućuju kontinuirano poboljšavanje web stranice i drugih usluga.",
         "title": "Analitički kolačići",
         "toggle": {
           "enabled": false,
@@ -556,8 +544,7 @@ Više informacija o tome što su kolačići i kako s njima radimo možete pron
         },
       },
       {
-        "description": "Naša web stranica djeluje još učinkovitije i bolje zahvaljujući ovim kolačićima.
-          Na primjer, omogućuju nam korištenje usluge razgovora i brzo i jednostavno odgovaranje na vaša pitanja.",
+        "description": "Naša web stranica djeluje još učinkovitije i bolje zahvaljujući ovim kolačićima. Na primjer, omogućuju nam korištenje usluge razgovora i brzo i jednostavno odgovaranje na vaša pitanja.",
         "title": "Funkcionalni kolačići",
         "toggle": {
           "enabled": false,
@@ -566,8 +553,7 @@ Više informacija o tome što su kolačići i kako s njima radimo možete pron
         },
       },
       {
-        "description": "Ovi kolačići nam pomažu mjeriti učinkovitost našeg oglašavanja i ciljanih ponuda usluga.
-          Marketing kolačići omogućuju nam donošenje vijesti koje bi vas mogle zanimati na internetu.",
+        "description": "Ovi kolačići nam pomažu mjeriti učinkovitost našeg oglašavanja i ciljanih ponuda usluga. Marketing kolačići omogućuju nam donošenje vijesti koje bi vas mogle zanimati na internetu.",
         "title": "Marketing kolačići",
         "toggle": {
           "enabled": false,
@@ -576,8 +562,7 @@ Više informacija o tome što su kolačići i kako s njima radimo možete pron
         },
       },
       {
-        "description": "Naše usluge bolje funkcioniraju ako ih možemo prilagoditi određenim korisnicima.
-          Dopuštanjem personalizacijskih kolačića povećavate šanse da pronađete sadržaj koji želite.",
+        "description": "Naše usluge bolje funkcioniraju ako ih možemo prilagoditi određenim korisnicima. Dopuštanjem personalizacijskih kolačića povećavate šanse da pronađete sadržaj koji želite.",
         "title": "Personalizacijski kolačići",
         "toggle": {
           "enabled": false,
@@ -623,8 +608,7 @@ Više informacija o tome što su kolačići i kako s njima radimo možete pron
               <a href="https://www.almacareer.com/gdpr" target="_blank">Pravila privatnosti</a>.",
       },
       {
-        "description": "Ovi kolačići su ključni za pravilno funkcioniranje naše web stranice i stoga ih nije moguće onemogućiti.
-          Bez njih nije moguće prikazati sadržaj ili se prijaviti na našu web stranicu.",
+        "description": "Ovi kolačići su ključni za pravilno funkcioniranje naše web stranice i stoga ih nije moguće onemogućiti. Bez njih nije moguće prikazati sadržaj ili se prijaviti na našu web stranicu.",
         "title": "Tehnički nužni kolačići",
         "toggle": {
           "enabled": true,
@@ -633,8 +617,7 @@ Više informacija o tome što su kolačići i kako s njima radimo možete pron
         },
       },
       {
-        "description": "Ovi nam pomažu pratiti koliko ljudi posjećuje našu web stranicu i kako je koriste.
-          Te informacije nam omogućuju kontinuirano poboljšavanje web stranice i drugih usluga.",
+        "description": "Ovi nam pomažu pratiti koliko ljudi posjećuje našu web stranicu i kako je koriste. Te informacije nam omogućuju kontinuirano poboljšavanje web stranice i drugih usluga.",
         "title": "Analitički kolačići",
         "toggle": {
           "enabled": false,
@@ -643,8 +626,7 @@ Više informacija o tome što su kolačići i kako s njima radimo možete pron
         },
       },
       {
-        "description": "Naša web stranica djeluje još učinkovitije i bolje zahvaljujući ovim kolačićima.
-          Na primjer, omogućuju nam korištenje usluge razgovora i brzo i jednostavno odgovaranje na vaša pitanja.",
+        "description": "Naša web stranica djeluje još učinkovitije i bolje zahvaljujući ovim kolačićima. Na primjer, omogućuju nam korištenje usluge razgovora i brzo i jednostavno odgovaranje na vaša pitanja.",
         "title": "Funkcionalni kolačići",
         "toggle": {
           "enabled": false,
@@ -653,8 +635,7 @@ Više informacija o tome što su kolačići i kako s njima radimo možete pron
         },
       },
       {
-        "description": "Ovi kolačići nam pomažu mjeriti učinkovitost našeg oglašavanja i ciljanih ponuda usluga.
-          Marketing kolačići omogućuju nam donošenje vijesti koje bi vas mogle zanimati na internetu.",
+        "description": "Ovi kolačići nam pomažu mjeriti učinkovitost našeg oglašavanja i ciljanih ponuda usluga. Marketing kolačići omogućuju nam donošenje vijesti koje bi vas mogle zanimati na internetu.",
         "title": "Marketing kolačići",
         "toggle": {
           "enabled": false,
@@ -663,8 +644,7 @@ Više informacija o tome što su kolačići i kako s njima radimo možete pron
         },
       },
       {
-        "description": "Naše usluge bolje funkcioniraju ako ih možemo prilagoditi određenim korisnicima.
-          Dopuštanjem personalizacijskih kolačića povećavate šanse da pronađete sadržaj koji želite.",
+        "description": "Naše usluge bolje funkcioniraju ako ih možemo prilagoditi određenim korisnicima. Dopuštanjem personalizacijskih kolačića povećavate šanse da pronađete sadržaj koji želite.",
         "title": "Personalizacijski kolačići",
         "toggle": {
           "enabled": false,
@@ -1374,8 +1354,7 @@ Več informacij o tem, kaj so piškotki in kako z njimi upravljamo, najdete n
               <a href="https://www.almacareer.com/gdpr" target="_blank">Pravilnik o zasebnosti</a>.",
       },
       {
-        "description": "Ti piškotki so bistveni za pravilno delovanje naše spletne strani in jih ni mogoče izklopiti.
-          Brez njih ne bi bilo mogoče prikazati vsebine ali se prijaviti na našo spletno stran.",
+        "description": "Ti piškotki so bistveni za pravilno delovanje naše spletne strani in jih ni mogoče izklopiti. Brez njih ne bi bilo mogoče prikazati vsebine ali se prijaviti na našo spletno stran.",
         "title": "Tehnično nujni piškotki",
         "toggle": {
           "enabled": true,
@@ -1384,8 +1363,7 @@ Več informacij o tem, kaj so piškotki in kako z njimi upravljamo, najdete n
         },
       },
       {
-        "description": "Ti nam pomagajo spremljati, koliko ljudi obišče našo spletno stran in kako jo uporabljajo.
-          Te informacije nam omogočajo nenehno izboljševanje spletne strani in drugih storitev.",
+        "description": "Ti nam pomagajo spremljati, koliko ljudi obišče našo spletno stran in kako jo uporabljajo. Te informacije nam omogočajo nenehno izboljševanje spletne strani in drugih storitev.",
         "title": "Analitični piškotki",
         "toggle": {
           "enabled": false,
@@ -1394,8 +1372,7 @@ Več informacij o tem, kaj so piškotki in kako z njimi upravljamo, najdete n
         },
       },
       {
-        "description": "Naša spletna stran je še učinkovitejša in bolje deluje zaradi teh piškotkov.
-          Na primer, omogočajo nam uporabo klepetalne storitve in hitro ter enostavno odgovarjanje na vaša vprašanja.",
+        "description": "Naša spletna stran je še učinkovitejša in bolje deluje zaradi teh piškotkov. Na primer, omogočajo nam uporabo klepetalne storitve in hitro ter enostavno odgovarjanje na vaša vprašanja.",
         "title": "Funkcionalni piškotki",
         "toggle": {
           "enabled": false,
@@ -1404,8 +1381,7 @@ Več informacij o tem, kaj so piškotki in kako z njimi upravljamo, najdete n
         },
       },
       {
-        "description": "Ti piškotki nam pomagajo meriti učinkovitost našega oglaševanja in ciljnih ponudb storitev.
-          Trženjski piškotki nam omogočajo, da vam na internetu prinašamo novice, ki vas morda zanimajo.",
+        "description": "Ti piškotki nam pomagajo meriti učinkovitost našega oglaševanja in ciljnih ponudb storitev. Trženjski piškotki nam omogočajo, da vam na internetu prinašamo novice, ki vas morda zanimajo.",
         "title": "Trženjski piškotki",
         "toggle": {
           "enabled": false,
@@ -1414,8 +1390,7 @@ Več informacij o tem, kaj so piškotki in kako z njimi upravljamo, najdete n
         },
       },
       {
-        "description": "Naše storitve bolje delujejo, če jih lahko prilagodimo določenim uporabnikom.
-          Z dovoljenjem piškotkov za prilagajanje povečate možnosti, da najdete vsebino, ki jo želite.",
+        "description": "Naše storitve bolje delujejo, če jih lahko prilagodimo določenim uporabnikom. Z dovoljenjem piškotkov za prilagajanje povečate možnosti, da najdete vsebino, ki jo želite.",
         "title": "Piškotki za prilagajanje",
         "toggle": {
           "enabled": false,
@@ -1461,8 +1436,7 @@ Več informacij o tem, kaj so piškotki in kako z njimi upravljamo, najdete n
               <a href="https://www.almacareer.com/gdpr" target="_blank">Pravilnik o zasebnosti</a>.",
       },
       {
-        "description": "Ti piškotki so bistveni za pravilno delovanje naše spletne strani in jih ni mogoče izklopiti.
-          Brez njih ne bi bilo mogoče prikazati vsebine ali se prijaviti na našo spletno stran.",
+        "description": "Ti piškotki so bistveni za pravilno delovanje naše spletne strani in jih ni mogoče izklopiti. Brez njih ne bi bilo mogoče prikazati vsebine ali se prijaviti na našo spletno stran.",
         "title": "Tehnično nujni piškotki",
         "toggle": {
           "enabled": true,
@@ -1471,8 +1445,7 @@ Več informacij o tem, kaj so piškotki in kako z njimi upravljamo, najdete n
         },
       },
       {
-        "description": "Ti nam pomagajo spremljati, koliko ljudi obišče našo spletno stran in kako jo uporabljajo.
-          Te informacije nam omogočajo nenehno izboljševanje spletne strani in drugih storitev.",
+        "description": "Ti nam pomagajo spremljati, koliko ljudi obišče našo spletno stran in kako jo uporabljajo. Te informacije nam omogočajo nenehno izboljševanje spletne strani in drugih storitev.",
         "title": "Analitični piškotki",
         "toggle": {
           "enabled": false,
@@ -1481,8 +1454,7 @@ Več informacij o tem, kaj so piškotki in kako z njimi upravljamo, najdete n
         },
       },
       {
-        "description": "Naša spletna stran je še učinkovitejša in bolje deluje zaradi teh piškotkov.
-          Na primer, omogočajo nam uporabo klepetalne storitve in hitro ter enostavno odgovarjanje na vaša vprašanja.",
+        "description": "Naša spletna stran je še učinkovitejša in bolje deluje zaradi teh piškotkov. Na primer, omogočajo nam uporabo klepetalne storitve in hitro ter enostavno odgovarjanje na vaša vprašanja.",
         "title": "Funkcionalni piškotki",
         "toggle": {
           "enabled": false,
@@ -1491,8 +1463,7 @@ Več informacij o tem, kaj so piškotki in kako z njimi upravljamo, najdete n
         },
       },
       {
-        "description": "Ti piškotki nam pomagajo meriti učinkovitost našega oglaševanja in ciljnih ponudb storitev.
-          Trženjski piškotki nam omogočajo, da vam na internetu prinašamo novice, ki vas morda zanimajo.",
+        "description": "Ti piškotki nam pomagajo meriti učinkovitost našega oglaševanja in ciljnih ponudb storitev. Trženjski piškotki nam omogočajo, da vam na internetu prinašamo novice, ki vas morda zanimajo.",
         "title": "Trženjski piškotki",
         "toggle": {
           "enabled": false,
@@ -1501,8 +1472,7 @@ Več informacij o tem, kaj so piškotki in kako z njimi upravljamo, najdete n
         },
       },
       {
-        "description": "Naše storitve bolje delujejo, če jih lahko prilagodimo določenim uporabnikom.
-          Z dovoljenjem piškotkov za prilagajanje povečate možnosti, da najdete vsebino, ki jo želite.",
+        "description": "Naše storitve bolje delujejo, če jih lahko prilagodimo določenim uporabnikom. Z dovoljenjem piškotkov za prilagajanje povečate možnosti, da najdete vsebino, ki jo želite.",
         "title": "Piškotki za prilagajanje",
         "toggle": {
           "enabled": false,

--- a/src/languages/__tests__/langConfig.test.ts
+++ b/src/languages/__tests__/langConfig.test.ts
@@ -8,7 +8,7 @@ import { config as configRu } from '../ru';
 import { config as configSk } from '../sk';
 import { config as configSl } from '../sl';
 import { config as configUk } from '../uk';
-import { SecondaryButtonMode } from '../../constants/SecondaryButtonMode';
+import { SecondaryButtonMode } from '../../constants';
 
 describe.each([
   ['cs', configCs],

--- a/src/languages/cs.ts
+++ b/src/languages/cs.ts
@@ -5,6 +5,11 @@ import {
   isSettingsButtonNotShown,
   pluralize,
   legalizeAlmaCareer,
+  assembleCategoryNecessary,
+  assembleCategoryAnalytics,
+  assembleCategoryFunctionality,
+  assembleCategoryAd,
+  assembleCategoryPersonalization,
 } from '../utils';
 import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
 import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
@@ -65,56 +70,26 @@ export const config = (
               `Další informace o tom, co jsou cookies a jak s nimi pracujeme, najdete
               v <a href="https://www.almacareer.com/gdpr" target="_blank">Zásadách cookies</a>.`),
         },
-        {
-          title: 'Technicky nezbytné Cookies',
-          description: `Tyto Cookies jsou pro správné fungování našeho webu nezbytné, proto není možné je vypnout.
-          Bez nich by na našich stránkách např. nešel zobrazit žádný obsah nebo by nefungovalo přihlášení.`,
-          toggle: {
-            value: CookieConsentCategory.NECESSARY,
-            enabled: true,
-            readonly: true,
-          },
-        },
-        {
-          title: 'Analytické Cookies',
-          description: `Pomocí nich sledujeme, kolik lidí náš web navštěvuje a jak ho používají.
-          Díky tomu můžeme stránky a další služby neustále vylepšovat.`,
-          toggle: {
-            value: CookieConsentCategory.ANALYTICS,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Funkční Cookies',
-          description: `Díky těmto Cookies jsou naše stránky ještě výkonnější a fungují lépe.
-          Například nám umožňují používat chat, abychom na vaše otázky mohli odpovídat rychle a jednoduše.`,
-          toggle: {
-            value: CookieConsentCategory.FUNCTIONALITY,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Marketingové Cookies',
-          description: `S těmito Cookies můžeme měřit, jak efektivní je naše reklama a cílené nabídky našich služeb.
-          Marketingové Cookies nám umožní vás na Internetu upozornit na novinky, které vás můžou zajímat.`,
-          toggle: {
-            value: CookieConsentCategory.AD,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Personalizační Cookies',
-          description: `Naše služby fungují lépe, když je můžeme přizpůsobit na míru konkrétnímu uživateli.
-          Povolením Personalizačních cookies zvýšíte šanci, že najdete právě takový obsah, jaký hledáte.`,
-          toggle: {
-            value: CookieConsentCategory.PERSONALIZATION,
-            enabled: false,
-            readonly: false,
-          },
-        },
+        assembleCategoryNecessary(
+          'Technicky nezbytné Cookies',
+          'Tyto Cookies jsou pro správné fungování našeho webu nezbytné, proto není možné je vypnout. Bez nich by na našich stránkách např. nešel zobrazit žádný obsah nebo by nefungovalo přihlášení.',
+        ),
+        assembleCategoryAnalytics(
+          'Analytické Cookies',
+          'Pomocí nich sledujeme, kolik lidí náš web navštěvuje a jak ho používají. Díky tomu můžeme stránky a další služby neustále vylepšovat.',
+        ),
+        assembleCategoryFunctionality(
+          'Funkční Cookies',
+          'Díky těmto Cookies jsou naše stránky ještě výkonnější a fungují lépe. Například nám umožňují používat chat, abychom na vaše otázky mohli odpovídat rychle a jednoduše.',
+        ),
+        assembleCategoryAd(
+          'Marketingové Cookies',
+          'S těmito Cookies můžeme měřit, jak efektivní je naše reklama a cílené nabídky našich služeb. Marketingové Cookies nám umožní vás na Internetu upozornit na novinky, které vás můžou zajímat.',
+        ),
+        assembleCategoryPersonalization(
+          'Personalizační Cookies',
+          'Naše služby fungují lépe, když je můžeme přizpůsobit na míru konkrétnímu uživateli. Povolením Personalizačních cookies zvýšíte šanci, že najdete právě takový obsah, jaký hledáte.',
+        ),
       ],
     },
   };

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -4,6 +4,11 @@ import {
   assembleSecondaryButton,
   isSettingsButtonNotShown,
   legalizeAlmaCareer,
+  assembleCategoryNecessary,
+  assembleCategoryAnalytics,
+  assembleCategoryFunctionality,
+  assembleCategoryAd,
+  assembleCategoryPersonalization,
 } from '../utils';
 import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
 import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
@@ -66,51 +71,26 @@ export const config = (
               finden Sie in unsere
               <a href="https://www.almacareer.com/gdpr" target="_blank">Datenschutzrichtlinien</a>.`),
         },
-        {
-          title: 'Technisch notwendige Cookies',
-          description: `Diese Cookies sind für das reibungslose Funktionieren unserer Website unerlässlich und können daher nicht deaktiviert werden. Ohne sie könnten z. B. keine Inhalte auf unserer Seite angezeigt werden oder das Login würde nicht funktionieren.`,
-          toggle: {
-            value: CookieConsentCategory.NECESSARY,
-            enabled: true,
-            readonly: true,
-          },
-        },
-        {
-          title: 'Analytische Cookies',
-          description: `Wir verwenden diese Cookies, um zu verfolgen, wie viele Personen unsere Website besuchen und wie sie sie nutzen. Auf diese Weise können wir die Website und andere Dienste kontinuierlich verbessern.`,
-          toggle: {
-            value: CookieConsentCategory.ANALYTICS,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Funktionale Cookies',
-          description: `Diese Cookies machen unsere Website leistungsfähiger und funktionieren besser. Sie ermöglichen uns zum Beispiel die Nutzung des Chats, damit wir Ihre Fragen schnell und einfach beantworten können.`,
-          toggle: {
-            value: CookieConsentCategory.FUNCTIONALITY,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Marketing Cookies',
-          description: `Mit diesen Cookies können wir messen, wie effektiv unsere Werbung und gezielte Angebote unserer Dienste sind. Marketing Cookies ermöglichen es uns, Sie online auf Nachrichten hinzuweisen, die für Sie von Interesse sein könnten.`,
-          toggle: {
-            value: CookieConsentCategory.AD,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Personalisierung Cookies',
-          description: `Unsere Dienste funktionieren besser, wenn wir sie auf den einzelnen Nutzer zuschneiden können. Durch die Aktivierung von Personalisierungs-Cookies erhöhen Sie die Wahrscheinlichkeit, dass Sie genau die Inhalte finden, nach denen Sie suchen.`,
-          toggle: {
-            value: CookieConsentCategory.PERSONALIZATION,
-            enabled: false,
-            readonly: false,
-          },
-        },
+        assembleCategoryNecessary(
+          'Technisch notwendige Cookies',
+          'Diese Cookies sind für das reibungslose Funktionieren unserer Website unerlässlich und können daher nicht deaktiviert werden. Ohne sie könnten z. B. keine Inhalte auf unserer Seite angezeigt werden oder das Login würde nicht funktionieren.',
+        ),
+        assembleCategoryAnalytics(
+          'Analytische Cookies',
+          'Wir verwenden diese Cookies, um zu verfolgen, wie viele Personen unsere Website besuchen und wie sie sie nutzen. Auf diese Weise können wir die Website und andere Dienste kontinuierlich verbessern.',
+        ),
+        assembleCategoryFunctionality(
+          'Funktionale Cookies',
+          'Diese Cookies machen unsere Website leistungsfähiger und funktionieren besser. Sie ermöglichen uns zum Beispiel die Nutzung des Chats, damit wir Ihre Fragen schnell und einfach beantworten können.',
+        ),
+        assembleCategoryAd(
+          'Marketing Cookies',
+          'Mit diesen Cookies können wir messen, wie effektiv unsere Werbung und gezielte Angebote unserer Dienste sind. Marketing Cookies ermöglichen es uns, Sie online auf Nachrichten hinzuweisen, die für Sie von Interesse sein könnten.',
+        ),
+        assembleCategoryPersonalization(
+          'Personalisierung Cookies',
+          'Unsere Dienste funktionieren besser, wenn wir sie auf den einzelnen Nutzer zuschneiden können. Durch die Aktivierung von Personalisierungs-Cookies erhöhen Sie die Wahrscheinlichkeit, dass Sie genau die Inhalte finden, nach denen Sie suchen.',
+        ),
       ],
     },
   };

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -4,6 +4,11 @@ import {
   assembleSecondaryButton,
   isSettingsButtonNotShown,
   legalizeAlmaCareer,
+  assembleCategoryNecessary,
+  assembleCategoryAnalytics,
+  assembleCategoryFunctionality,
+  assembleCategoryAd,
+  assembleCategoryPersonalization,
 } from '../utils';
 import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
 import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
@@ -60,51 +65,26 @@ export const config = (
               `For more information about what cookies are and how we work with them, see our
               <a href="https://www.almacareer.com/gdpr" target="_blank">Cookie Policy</a>.`),
         },
-        {
-          title: 'Technically necessary cookies',
-          description: `These cookies are essential for the proper functioning of our website, and so they cannot be disabled. Without them, it would not be possible e.g. to display any content or to log in on our website.`,
-          toggle: {
-            value: CookieConsentCategory.NECESSARY,
-            enabled: true,
-            readonly: true,
-          },
-        },
-        {
-          title: 'Analytical cookies',
-          description: `These help us monitor how many people visit our website and how they use it. This information then enables us to continuously improve the website and other services.`,
-          toggle: {
-            value: CookieConsentCategory.ANALYTICS,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Functional cookies',
-          description: `Our website is even more efficient and works better thanks to these cookies. For example, they enable us to use the chat service and answer your questions quickly and easily.`,
-          toggle: {
-            value: CookieConsentCategory.FUNCTIONALITY,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Marketing cookies',
-          description: `These cookies help us to measure the effectiveness of our advertising and targeted service offers. Marketing cookies enable us to bring you news that may be of interest to you on the Internet.`,
-          toggle: {
-            value: CookieConsentCategory.AD,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Personalisation cookies',
-          description: `Our services work better if we can tailor them to specific users. By allowing personalisation cookies you increase your chances of finding the content you want.`,
-          toggle: {
-            value: CookieConsentCategory.PERSONALIZATION,
-            enabled: false,
-            readonly: false,
-          },
-        },
+        assembleCategoryNecessary(
+          'Technically necessary cookies',
+          'These cookies are essential for the proper functioning of our website, and so they cannot be disabled. Without them, it would not be possible e.g. to display any content or to log in on our website.',
+        ),
+        assembleCategoryAnalytics(
+          'Analytical cookies',
+          'These help us monitor how many people visit our website and how they use it. This information then enables us to continuously improve the website and other services.',
+        ),
+        assembleCategoryFunctionality(
+          'Functional cookies',
+          'Our website is even more efficient and works better thanks to these cookies. For example, they enable us to use the chat service and answer your questions quickly and easily.',
+        ),
+        assembleCategoryAd(
+          'Marketing cookies',
+          'These cookies help us to measure the effectiveness of our advertising and targeted service offers. Marketing cookies enable us to bring you news that may be of interest to you on the Internet.',
+        ),
+        assembleCategoryPersonalization(
+          'Personalisation cookies',
+          'Our services work better if we can tailor them to specific users. By allowing personalisation cookies you increase your chances of finding the content you want.',
+        ),
       ],
     },
   };

--- a/src/languages/hr.ts
+++ b/src/languages/hr.ts
@@ -5,6 +5,11 @@ import {
   isSettingsButtonNotShown,
   pluralize,
   legalizeAlmaCareer,
+  assembleCategoryNecessary,
+  assembleCategoryAnalytics,
+  assembleCategoryFunctionality,
+  assembleCategoryAd,
+  assembleCategoryPersonalization,
 } from '../utils';
 import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
 import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
@@ -62,56 +67,26 @@ export const config = (
               `Više informacija o tome što su kolačići i kako s njima radimo možete pronaći na stranici
               <a href="https://www.almacareer.com/gdpr" target="_blank">Pravila privatnosti</a>.`),
         },
-        {
-          title: 'Tehnički nužni kolačići',
-          description: `Ovi kolačići su ključni za pravilno funkcioniranje naše web stranice i stoga ih nije moguće onemogućiti.
-          Bez njih nije moguće prikazati sadržaj ili se prijaviti na našu web stranicu.`,
-          toggle: {
-            value: CookieConsentCategory.NECESSARY,
-            enabled: true,
-            readonly: true,
-          },
-        },
-        {
-          title: 'Analitički kolačići',
-          description: `Ovi nam pomažu pratiti koliko ljudi posjećuje našu web stranicu i kako je koriste.
-          Te informacije nam omogućuju kontinuirano poboljšavanje web stranice i drugih usluga.`,
-          toggle: {
-            value: CookieConsentCategory.ANALYTICS,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Funkcionalni kolačići',
-          description: `Naša web stranica djeluje još učinkovitije i bolje zahvaljujući ovim kolačićima.
-          Na primjer, omogućuju nam korištenje usluge razgovora i brzo i jednostavno odgovaranje na vaša pitanja.`,
-          toggle: {
-            value: CookieConsentCategory.FUNCTIONALITY,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Marketing kolačići',
-          description: `Ovi kolačići nam pomažu mjeriti učinkovitost našeg oglašavanja i ciljanih ponuda usluga.
-          Marketing kolačići omogućuju nam donošenje vijesti koje bi vas mogle zanimati na internetu.`,
-          toggle: {
-            value: CookieConsentCategory.AD,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Personalizacijski kolačići',
-          description: `Naše usluge bolje funkcioniraju ako ih možemo prilagoditi određenim korisnicima.
-          Dopuštanjem personalizacijskih kolačića povećavate šanse da pronađete sadržaj koji želite.`,
-          toggle: {
-            value: CookieConsentCategory.PERSONALIZATION,
-            enabled: false,
-            readonly: false,
-          },
-        },
+        assembleCategoryNecessary(
+          'Tehnički nužni kolačići',
+          'Ovi kolačići su ključni za pravilno funkcioniranje naše web stranice i stoga ih nije moguće onemogućiti. Bez njih nije moguće prikazati sadržaj ili se prijaviti na našu web stranicu.',
+        ),
+        assembleCategoryAnalytics(
+          'Analitički kolačići',
+          'Ovi nam pomažu pratiti koliko ljudi posjećuje našu web stranicu i kako je koriste. Te informacije nam omogućuju kontinuirano poboljšavanje web stranice i drugih usluga.',
+        ),
+        assembleCategoryFunctionality(
+          'Funkcionalni kolačići',
+          'Naša web stranica djeluje još učinkovitije i bolje zahvaljujući ovim kolačićima. Na primjer, omogućuju nam korištenje usluge razgovora i brzo i jednostavno odgovaranje na vaša pitanja.',
+        ),
+        assembleCategoryAd(
+          'Marketing kolačići',
+          'Ovi kolačići nam pomažu mjeriti učinkovitost našeg oglašavanja i ciljanih ponuda usluga. Marketing kolačići omogućuju nam donošenje vijesti koje bi vas mogle zanimati na internetu.',
+        ),
+        assembleCategoryPersonalization(
+          'Personalizacijski kolačići',
+          'Naše usluge bolje funkcioniraju ako ih možemo prilagoditi određenim korisnicima. Dopuštanjem personalizacijskih kolačića povećavate šanse da pronađete sadržaj koji želite.',
+        ),
       ],
     },
   };

--- a/src/languages/hr.ts
+++ b/src/languages/hr.ts
@@ -3,7 +3,6 @@ import {
   assembleDescriptionIntro,
   assembleSecondaryButton,
   isSettingsButtonNotShown,
-  pluralize,
   legalizeAlmaCareer,
   assembleCategoryNecessary,
   assembleCategoryAnalytics,

--- a/src/languages/hu.ts
+++ b/src/languages/hu.ts
@@ -4,6 +4,11 @@ import {
   assembleSecondaryButton,
   isSettingsButtonNotShown,
   legalizeAlmaCareer,
+  assembleCategoryNecessary,
+  assembleCategoryAnalytics,
+  assembleCategoryFunctionality,
+  assembleCategoryAd,
+  assembleCategoryPersonalization,
 } from '../utils';
 import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
 import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
@@ -65,51 +70,26 @@ export const config = (
               `További információkat arról, hogy mik azok a cookie-k és hogyan dolgozunk velük
               az <a href="https://www.almacareer.com/gdpr" target="_blank">Adatvédelmi szabályzat</a> oldalán találsz.`),
         },
-        {
-          title: 'Technikailag szükséges cookie-k',
-          description: `Ezek a cookie-k weboldalunk megfelelő működéséhez szükségesek, ezért kikapcsolásuk nem lehetséges. Nélkülük például semmilyen tartalom nem jelenhetne meg weboldalunkon, vagy nem működne a bejelentkezés.`,
-          toggle: {
-            value: CookieConsentCategory.NECESSARY,
-            enabled: true,
-            readonly: true,
-          },
-        },
-        {
-          title: 'Analitikai cookie-k',
-          description: `Segítségükkel nyomon követjük, hogy hányan látogatják oldalunkat, és hogyan használják. Ennek köszönhetően tehetjük meg webhelyünk és egyéb szolgáltatásaink folyamatos fejlesztését.`,
-          toggle: {
-            value: CookieConsentCategory.ANALYTICS,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Funkcionális cookie-k',
-          description: `Ezeknek a cookie-knak köszönhetően weboldalunk még hatékonyabban és jobban működik. Például lehetővé teszik számunkra a chat használatát, hogy gyorsan és egyszerűen válaszolhassunk kérdéseire.`,
-          toggle: {
-            value: CookieConsentCategory.FUNCTIONALITY,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Marketing cookie-k',
-          description: `Ezekkel a cookie-kkel mérhetjük le, mennyire hatékonyak a hirdetéseink és szolgáltatásaink célzott ajánlatai. A marketing cookie-k lehetővé teszik, hogy figyelmeztessük az interneten megjelenő olyan hírekre, amelyek érdekesek lehetnek az Ön számára.m`,
-          toggle: {
-            value: CookieConsentCategory.AD,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Személyre szabott cookie-k',
-          description: `Szolgáltatásaink jobban működnek, ha egy adott felhasználóra tudjuk szabni őket. A személyre szabott cookie-k engedélyezésével növeli annak esélyét, hogy éppen a keresett tartalmat találja meg.`,
-          toggle: {
-            value: CookieConsentCategory.PERSONALIZATION,
-            enabled: false,
-            readonly: false,
-          },
-        },
+        assembleCategoryNecessary(
+          'Technikailag szükséges cookie-k',
+          'Ezek a cookie-k weboldalunk megfelelő működéséhez szükségesek, ezért kikapcsolásuk nem lehetséges. Nélkülük például semmilyen tartalom nem jelenhetne meg weboldalunkon, vagy nem működne a bejelentkezés.',
+        ),
+        assembleCategoryAnalytics(
+          'Analitikai cookie-k',
+          'Segítségükkel nyomon követjük, hogy hányan látogatják oldalunkat, és hogyan használják. Ennek köszönhetően tehetjük meg webhelyünk és egyéb szolgáltatásaink folyamatos fejlesztését.',
+        ),
+        assembleCategoryFunctionality(
+          'Funkcionális cookie-k',
+          'Ezeknek a cookie-knak köszönhetően weboldalunk még hatékonyabban és jobban működik. Például lehetővé teszik számunkra a chat használatát, hogy gyorsan és egyszerűen válaszolhassunk kérdéseire.',
+        ),
+        assembleCategoryAd(
+          'Marketing cookie-k',
+          'Ezekkel a cookie-kkel mérhetjük le, mennyire hatékonyak a hirdetéseink és szolgáltatásaink célzott ajánlatai. A marketing cookie-k lehetővé teszik, hogy figyelmeztessük az interneten megjelenő olyan hírekre, amelyek érdekesek lehetnek az Ön számára.m',
+        ),
+        assembleCategoryPersonalization(
+          'Személyre szabott cookie-k',
+          'Szolgáltatásaink jobban működnek, ha egy adott felhasználóra tudjuk szabni őket. A személyre szabott cookie-k engedélyezésével növeli annak esélyét, hogy éppen a keresett tartalmat találja meg.',
+        ),
       ],
     },
   };

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -5,6 +5,11 @@ import {
   isSettingsButtonNotShown,
   legalizeAlmaCareer,
   pluralize,
+  assembleCategoryNecessary,
+  assembleCategoryAnalytics,
+  assembleCategoryFunctionality,
+  assembleCategoryAd,
+  assembleCategoryPersonalization,
 } from '../utils';
 import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
 import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
@@ -65,51 +70,26 @@ export const config = (
               `Więcej informacji na temat tego, czym są pliki cookies i jak z nimi pracujemy, znajdziesz w naszej
               <a href="https://www.almacareer.com/gdpr" target="_blank">Polityce plików cookie</a>.`),
         },
-        {
-          title: 'Technicznie niezbędne pliki cookies',
-          description: `Te pliki cookies są niezbędne do prawidłowego funkcjonowania naszej strony internetowej, dlatego nie ma możliwości ich wyłączenia. Bez nich na naszej stronie na przykład nie można byłoby wyświetlić żadnej treści lub nie działałoby logowanie.`,
-          toggle: {
-            value: CookieConsentCategory.NECESSARY,
-            enabled: true,
-            readonly: true,
-          },
-        },
-        {
-          title: 'Analityczne pliki cookies',
-          description: `Używamy ich do śledzenia, ile osób odwiedza naszą stronę internetową i jak z niej korzysta. Dzięki temu możemy stale ulepszać stronę i inne usługi.`,
-          toggle: {
-            value: CookieConsentCategory.ANALYTICS,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Funkcjonalne pliki cookies',
-          description: `Te pliki cookies sprawiają, że nasza strona internetowa jest jeszcze bardziej wydajna i działa lepiej. Pozwalają nam na przykład korzystać z czatu, dzięki temu możemy szybko i łatwo odpowiadać na Twoje pytania.`,
-          toggle: {
-            value: CookieConsentCategory.FUNCTIONALITY,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Marketingowe pliki cookies',
-          description: `Za pomocą tych plików cookies możemy mierzyć, jak skuteczne są nasze reklamy i ukierunkowane oferty naszych usług. Marketingowe pliki cookies pozwalają nam powiadamiać Cię w Internecie o nowościach, które mogą Cię zainteresować.`,
-          toggle: {
-            value: CookieConsentCategory.AD,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Personalizacyjne pliki cookies',
-          description: `Nasze usługi działają lepiej, gdy możemy je dostosować do konkretnego użytkownika. Włączeniem personalizacyjnych plików cookies zwiększasz szansę na znalezienie właśnie tych treści, których poszukujesz.`,
-          toggle: {
-            value: CookieConsentCategory.PERSONALIZATION,
-            enabled: false,
-            readonly: false,
-          },
-        },
+        assembleCategoryNecessary(
+          'Technicznie niezbędne pliki cookies',
+          'Te pliki cookies są niezbędne do prawidłowego funkcjonowania naszej strony internetowej, dlatego nie ma możliwości ich wyłączenia. Bez nich na naszej stronie na przykład nie można byłoby wyświetlić żadnej treści lub nie działałoby logowanie.',
+        ),
+        assembleCategoryAnalytics(
+          'Analityczne pliki cookies',
+          'Używamy ich do śledzenia, ile osób odwiedza naszą stronę internetową i jak z niej korzysta. Dzięki temu możemy stale ulepszać stronę i inne usługi.',
+        ),
+        assembleCategoryFunctionality(
+          'Funkcjonalne pliki cookies',
+          'Te pliki cookies sprawiają, że nasza strona internetowa jest jeszcze bardziej wydajna i działa lepiej. Pozwalają nam na przykład korzystać z czatu, dzięki temu możemy szybko i łatwo odpowiadać na Twoje pytania.',
+        ),
+        assembleCategoryAd(
+          'Marketingowe pliki cookies',
+          'Za pomocą tych plików cookies możemy mierzyć, jak skuteczne są nasze reklamy i ukierunkowane oferty naszych usług. Marketingowe pliki cookies pozwalają nam powiadamiać Cię w Internecie o nowościach, które mogą Cię zainteresować.',
+        ),
+        assembleCategoryPersonalization(
+          'Personalizacyjne pliki cookies',
+          'Nasze usługi działają lepiej, gdy możemy je dostosować do konkretnego użytkownika. Włączeniem personalizacyjnych plików cookies zwiększasz szansę na znalezienie właśnie tych treści, których poszukujesz.',
+        ),
       ],
     },
   };

--- a/src/languages/ru.ts
+++ b/src/languages/ru.ts
@@ -5,6 +5,11 @@ import {
   isSettingsButtonNotShown,
   legalizeAlmaCareer,
   pluralize,
+  assembleCategoryNecessary,
+  assembleCategoryAnalytics,
+  assembleCategoryFunctionality,
+  assembleCategoryAd,
+  assembleCategoryPersonalization,
 } from '../utils';
 import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
 import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
@@ -66,51 +71,26 @@ export const config = (
               `Вы можете найти дополнительную информацию о том, что такое файлы cookies, и как мы с ними работаем,
               на странице <a href="https://www.almacareer.com/gdpr" target="_blank">Политика конфиденциальности персональных данных</a>.`),
         },
-        {
-          title: 'Технически необходимые файлы cookie',
-          description: `Эти файлы cookie необходимы для правильной работы нашего веб-сайта, поэтому их невозможно отключить. Без них, например, на нашем веб-сайте невозможно было бы изобразить какое-либо содержание или было бы невозможно войти в систему.`,
-          toggle: {
-            value: CookieConsentCategory.NECESSARY,
-            enabled: true,
-            readonly: true,
-          },
-        },
-        {
-          title: 'Аналитические файлы cookie',
-          description: `Мы используем их, чтобы отслеживать, сколько людей посещают наш веб-сайт и как они его используют. Это позволяет нам постоянно улучшать наш веб-сайт и другие услуги.`,
-          toggle: {
-            value: CookieConsentCategory.ANALYTICS,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Функциональные файлы cookie',
-          description: `Благодаря этим файлам cookie наш веб-сайт стал еще продуктивнее и улучшил работу. Например, они позволяют нам использовать чат, чтобы мы могли быстро и просто ответить на вопросы.`,
-          toggle: {
-            value: CookieConsentCategory.FUNCTIONALITY,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Маркетинговые файлы cookie',
-          description: `С помощью этих файлов cookie мы можем измерить, насколько эффективны наша реклама и целевые предложения наших услуг. Маркетинговые файлы cookie позволяют нам по Интернету информировать Вас о новостях, которые могут вас заинтересовать.`,
-          toggle: {
-            value: CookieConsentCategory.AD,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Файлы cookie для персонализации',
-          description: `Наши услуги работают лучше, когда мы можем приспособить их к конкретному пользователю. Включив файлы cookie для персонализации, вы повысите вероятность того, что найдете именно то содержание, которое ищете.`,
-          toggle: {
-            value: CookieConsentCategory.PERSONALIZATION,
-            enabled: false,
-            readonly: false,
-          },
-        },
+        assembleCategoryNecessary(
+          'Технически необходимые файлы cookie',
+          'Эти файлы cookie необходимы для правильной работы нашего веб-сайта, поэтому их невозможно отключить. Без них, например, на нашем веб-сайте невозможно было бы изобразить какое-либо содержание или было бы невозможно войти в систему.',
+        ),
+        assembleCategoryAnalytics(
+          'Аналитические файлы cookie',
+          'Мы используем их, чтобы отслеживать, сколько людей посещают наш веб-сайт и как они его используют. Это позволяет нам постоянно улучшать наш веб-сайт и другие услуги.',
+        ),
+        assembleCategoryFunctionality(
+          'Функциональные файлы cookie',
+          'Благодаря этим файлам cookie наш веб-сайт стал еще продуктивнее и улучшил работу. Например, они позволяют нам использовать чат, чтобы мы могли быстро и просто ответить на вопросы.',
+        ),
+        assembleCategoryAd(
+          'Маркетинговые файлы cookie',
+          'С помощью этих файлов cookie мы можем измерить, насколько эффективны наша реклама и целевые предложения наших услуг. Маркетинговые файлы cookie позволяют нам по Интернету информировать Вас о новостях, которые могут вас заинтересовать.',
+        ),
+        assembleCategoryPersonalization(
+          'Файлы cookie для персонализации',
+          'Наши услуги работают лучше, когда мы можем приспособить их к конкретному пользователю. Включив файлы cookie для персонализации, вы повысите вероятность того, что найдете именно то содержание, которое ищете.',
+        ),
       ],
     },
   };

--- a/src/languages/sk.ts
+++ b/src/languages/sk.ts
@@ -5,6 +5,11 @@ import {
   isSettingsButtonNotShown,
   legalizeAlmaCareer,
   pluralize,
+  assembleCategoryNecessary,
+  assembleCategoryAnalytics,
+  assembleCategoryFunctionality,
+  assembleCategoryAd,
+  assembleCategoryPersonalization,
 } from '../utils';
 import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
 import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
@@ -65,51 +70,26 @@ export const config = (
               `Ďalšie informácie o tom, čo sú cookies a ako s nimi pracujeme, nájdete
               v <a href="https://www.almacareer.com/gdpr" target="_blank">Zásadách cookies</a>.`),
         },
-        {
-          title: 'Technicky nevyhnutné cookies',
-          description: `Tieto cookies sú pre správne fungovanie nášho webu nevyhnutné, preto nie je možné ich vypnúť. Bez nich by sa na našich stránkach napr. nedal zobraziť žiadny obsah alebo by nefungovalo prihlásenie.`,
-          toggle: {
-            value: CookieConsentCategory.NECESSARY,
-            enabled: true,
-            readonly: true,
-          },
-        },
-        {
-          title: 'Analytické cookies',
-          description: `Pomocou nich sledujeme, koľko ľudí náš web navštevuje a ako ho používajú. Vďaka tomu môžeme stránky a ďalšie služby neustále vylepšovať.`,
-          toggle: {
-            value: CookieConsentCategory.ANALYTICS,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Funkčné cookies',
-          description: `Vďaka týmto cookies sú naše stránky ešte výkonnejšie a fungujú lepšie. Napríklad nám umožňujú používať chat, aby sme na vaše otázky mohli odpovedať rýchlo a jednoducho.`,
-          toggle: {
-            value: CookieConsentCategory.FUNCTIONALITY,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Marketingové cookies',
-          description: `S týmito cookies môžeme merať, aká efektívna je naša reklama a cielené ponuky našich služieb. Marketingové cookies nám umožnia vás na internete upozorniť na novinky, ktoré vás môžu zaujímať.`,
-          toggle: {
-            value: CookieConsentCategory.AD,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Personalizačné cookies',
-          description: `Naše služby fungujú lepšie, keď ich môžeme prispôsobiť na mieru konkrétnemu používateľovi. Povolením personalizačných cookies zvýšite šancu, že nájdete práve taký obsah, aký hľadáte.`,
-          toggle: {
-            value: CookieConsentCategory.PERSONALIZATION,
-            enabled: false,
-            readonly: false,
-          },
-        },
+        assembleCategoryNecessary(
+          'Technicky nevyhnutné cookies',
+          'Tieto cookies sú pre správne fungovanie nášho webu nevyhnutné, preto nie je možné ich vypnúť. Bez nich by sa na našich stránkach napr. nedal zobraziť žiadny obsah alebo by nefungovalo prihlásenie.',
+        ),
+        assembleCategoryAnalytics(
+          'Analytické cookies',
+          'Pomocou nich sledujeme, koľko ľudí náš web navštevuje a ako ho používajú. Vďaka tomu môžeme stránky a ďalšie služby neustále vylepšovať.',
+        ),
+        assembleCategoryFunctionality(
+          'Funkčné cookies',
+          'Vďaka týmto cookies sú naše stránky ešte výkonnejšie a fungujú lepšie. Napríklad nám umožňujú používať chat, aby sme na vaše otázky mohli odpovedať rýchlo a jednoducho.',
+        ),
+        assembleCategoryAd(
+          'Marketingové cookies',
+          'S týmito cookies môžeme merať, aká efektívna je naša reklama a cielené ponuky našich služieb. Marketingové cookies nám umožnia vás na internete upozorniť na novinky, ktoré vás môžu zaujímať.',
+        ),
+        assembleCategoryPersonalization(
+          'Personalizačné cookies',
+          'Naše služby fungujú lepšie, keď ich môžeme prispôsobiť na mieru konkrétnemu používateľovi. Povolením personalizačných cookies zvýšite šancu, že nájdete práve taký obsah, aký hľadáte.',
+        ),
       ],
     },
   };

--- a/src/languages/sl.ts
+++ b/src/languages/sl.ts
@@ -5,6 +5,11 @@ import {
   isSettingsButtonNotShown,
   pluralize,
   legalizeAlmaCareer,
+  assembleCategoryNecessary,
+  assembleCategoryAnalytics,
+  assembleCategoryFunctionality,
+  assembleCategoryAd,
+  assembleCategoryPersonalization,
 } from '../utils';
 import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
 import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
@@ -62,56 +67,26 @@ export const config = (
               `Več informacij o tem, kaj so piškotki in kako z njimi upravljamo, najdete na strani
               <a href="https://www.almacareer.com/gdpr" target="_blank">Pravilnik o zasebnosti</a>.`),
         },
-        {
-          title: 'Tehnično nujni piškotki',
-          description: `Ti piškotki so bistveni za pravilno delovanje naše spletne strani in jih ni mogoče izklopiti.
-          Brez njih ne bi bilo mogoče prikazati vsebine ali se prijaviti na našo spletno stran.`,
-          toggle: {
-            value: CookieConsentCategory.NECESSARY,
-            enabled: true,
-            readonly: true,
-          },
-        },
-        {
-          title: 'Analitični piškotki',
-          description: `Ti nam pomagajo spremljati, koliko ljudi obišče našo spletno stran in kako jo uporabljajo.
-          Te informacije nam omogočajo nenehno izboljševanje spletne strani in drugih storitev.`,
-          toggle: {
-            value: CookieConsentCategory.ANALYTICS,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Funkcionalni piškotki',
-          description: `Naša spletna stran je še učinkovitejša in bolje deluje zaradi teh piškotkov.
-          Na primer, omogočajo nam uporabo klepetalne storitve in hitro ter enostavno odgovarjanje na vaša vprašanja.`,
-          toggle: {
-            value: CookieConsentCategory.FUNCTIONALITY,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Trženjski piškotki',
-          description: `Ti piškotki nam pomagajo meriti učinkovitost našega oglaševanja in ciljnih ponudb storitev.
-          Trženjski piškotki nam omogočajo, da vam na internetu prinašamo novice, ki vas morda zanimajo.`,
-          toggle: {
-            value: CookieConsentCategory.AD,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Piškotki za prilagajanje',
-          description: `Naše storitve bolje delujejo, če jih lahko prilagodimo določenim uporabnikom.
-          Z dovoljenjem piškotkov za prilagajanje povečate možnosti, da najdete vsebino, ki jo želite.`,
-          toggle: {
-            value: CookieConsentCategory.PERSONALIZATION,
-            enabled: false,
-            readonly: false,
-          },
-        },
+        assembleCategoryNecessary(
+          'Tehnično nujni piškotki',
+          'Ti piškotki so bistveni za pravilno delovanje naše spletne strani in jih ni mogoče izklopiti. Brez njih ne bi bilo mogoče prikazati vsebine ali se prijaviti na našo spletno stran.',
+        ),
+        assembleCategoryAnalytics(
+          'Analitični piškotki',
+          'Ti nam pomagajo spremljati, koliko ljudi obišče našo spletno stran in kako jo uporabljajo. Te informacije nam omogočajo nenehno izboljševanje spletne strani in drugih storitev.',
+        ),
+        assembleCategoryFunctionality(
+          'Funkcionalni piškotki',
+          'Naša spletna stran je še učinkovitejša in bolje deluje zaradi teh piškotkov. Na primer, omogočajo nam uporabo klepetalne storitve in hitro ter enostavno odgovarjanje na vaša vprašanja.',
+        ),
+        assembleCategoryAd(
+          'Trženjski piškotki',
+          'Ti piškotki nam pomagajo meriti učinkovitost našega oglaševanja in ciljnih ponudb storitev. Trženjski piškotki nam omogočajo, da vam na internetu prinašamo novice, ki vas morda zanimajo.',
+        ),
+        assembleCategoryPersonalization(
+          'Piškotki za prilagajanje',
+          'Naše storitve bolje delujejo, če jih lahko prilagodimo določenim uporabnikom. Z dovoljenjem piškotkov za prilagajanje povečate možnosti, da najdete vsebino, ki jo želite.',
+        ),
       ],
     },
   };

--- a/src/languages/sl.ts
+++ b/src/languages/sl.ts
@@ -3,7 +3,6 @@ import {
   assembleDescriptionIntro,
   assembleSecondaryButton,
   isSettingsButtonNotShown,
-  pluralize,
   legalizeAlmaCareer,
   assembleCategoryNecessary,
   assembleCategoryAnalytics,

--- a/src/languages/uk.ts
+++ b/src/languages/uk.ts
@@ -5,6 +5,11 @@ import {
   isSettingsButtonNotShown,
   legalizeAlmaCareer,
   pluralize,
+  assembleCategoryNecessary,
+  assembleCategoryAnalytics,
+  assembleCategoryFunctionality,
+  assembleCategoryAd,
+  assembleCategoryPersonalization,
 } from '../utils';
 import { ExtraMessages, Values, VanillaCookieConsent } from '../types';
 import { CookieConsentCategory, SecondaryButtonMode } from '../constants';
@@ -65,51 +70,26 @@ export const config = (
               `Додаткову інформацію про те, що таке файли Cookies, і як ми з ними працюємо, можна отримати на сторінках
               <a href="https://www.almacareer.com/gdpr" target="_blank">Політика конфіденційності</a>.`),
         },
-        {
-          title: 'Технічно необхідні файли Cookies',
-          description: `Ці файли Cookies необхідні для правильного функціонування нашого сайту, тому вимкнути їх неможливо. Без них було б неможливо відображати на нашому сайті його контент, або не працював би вхід на сайт.`,
-          toggle: {
-            value: CookieConsentCategory.NECESSARY,
-            enabled: true,
-            readonly: true,
-          },
-        },
-        {
-          title: 'Аналітичні файли Cookies',
-          description: `Ми використовуємо їх для відстеження того, скільки людей відвідують наш веб-сайт і як вони ним користуються. Завдяки цьому ми можемо постійно покращувати сайт та інші сервіси.`,
-          toggle: {
-            value: CookieConsentCategory.ANALYTICS,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Функціональні файли Cookies',
-          description: `Ці файли Cookies роблять наш сайт ще більш ефективним і покращують його роботу. Наприклад, вони дозволяють нам використовувати чат, щоб швидко і легко відповідати на ваші запитання.`,
-          toggle: {
-            value: CookieConsentCategory.FUNCTIONALITY,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Маркетингові файли Cookies',
-          description: `За допомогою цих файлів Cookies ми можемо оцінити, наскільки ефективна наша реклама і цільові пропозиції наших послуг. Маркетингові файли Cookies дозволяють нам інформувати Вас в Інтернеті про новини, які можуть вас зацікавити.`,
-          toggle: {
-            value: CookieConsentCategory.AD,
-            enabled: false,
-            readonly: false,
-          },
-        },
-        {
-          title: 'Персоналізовані файли Cookies',
-          description: `Наші сервіси працюють краще, коли ми можемо адаптувати їх до конкретного користувача. Дозволивши персоналізовані файли Cookies, ви збільшуєте ймовірність того, що знайдете потрібний контент.`,
-          toggle: {
-            value: CookieConsentCategory.PERSONALIZATION,
-            enabled: false,
-            readonly: false,
-          },
-        },
+        assembleCategoryNecessary(
+          'Технічно необхідні файли Cookies',
+          'Ці файли Cookies необхідні для правильного функціонування нашого сайту, тому вимкнути їх неможливо. Без них було б неможливо відображати на нашому сайті його контент, або не працював би вхід на сайт.',
+        ),
+        assembleCategoryAnalytics(
+          'Аналітичні файли Cookies',
+          'Ми використовуємо їх для відстеження того, скільки людей відвідують наш веб-сайт і як вони ним користуються. Завдяки цьому ми можемо постійно покращувати сайт та інші сервіси.',
+        ),
+        assembleCategoryFunctionality(
+          'Функціональні файли Cookies',
+          'Ці файли Cookies роблять наш сайт ще більш ефективним і покращують його роботу. Наприклад, вони дозволяють нам використовувати чат, щоб швидко і легко відповідати на ваші запитання.',
+        ),
+        assembleCategoryAd(
+          'Маркетингові файли Cookies',
+          'За допомогою цих файлів Cookies ми можемо оцінити, наскільки ефективна наша реклама і цільові пропозиції наших послуг. Маркетингові файли Cookies дозволяють нам інформувати Вас в Інтернеті про новини, які можуть вас зацікавити.',
+        ),
+        assembleCategoryPersonalization(
+          'Персоналізовані файли Cookies',
+          'Наші сервіси працюють краще, коли ми можемо адаптувати їх до конкретного користувача. Дозволивши персоналізовані файли Cookies, ви збільшуєте ймовірність того, що знайдете потрібний контент.',
+        ),
       ],
     },
   };

--- a/src/types/vanilla-cookieconsent.ts
+++ b/src/types/vanilla-cookieconsent.ts
@@ -43,7 +43,7 @@ export namespace VanillaCookieConsent {
     SETTINGS = 'settings',
   }
 
-  interface ModalPrimaryButton {
+  export interface ModalPrimaryButton {
     text?: string;
     role?: PrimaryButtonRole;
   }
@@ -53,7 +53,7 @@ export namespace VanillaCookieConsent {
     role?: SecondaryButtonRole;
   }
 
-  interface ModalBlockToggle {
+  export interface ModalBlockToggle {
     value?: string;
     enabled?: boolean;
     readonly?: boolean;
@@ -66,21 +66,21 @@ export namespace VanillaCookieConsent {
     [key: string]: string | boolean | undefined;
   }
 
-  interface ModalBlock {
+  export interface ModalBlock {
     title?: string;
     description?: string;
     toggle?: ModalBlockToggle;
     cookie_table?: CookieTableItem[];
   }
 
-  interface ConsentModal {
+  export interface ConsentModal {
     title?: string;
     description?: string;
     primary_btn?: ModalPrimaryButton;
     secondary_btn?: ModalSecondaryButton;
   }
 
-  interface SettingsModal {
+  export interface SettingsModal {
     title?: string;
     accept_all_btn?: string;
     reject_all_btn?: string;
@@ -127,20 +127,20 @@ export namespace VanillaCookieConsent {
     ZOOM = 'zoom',
   }
 
-  interface GuiConsentModal {
+  export interface GuiConsentModal {
     layout: GuiConsentLayout;
     position: GuiConsentPosition;
     transition?: Transition;
     swap_buttons: boolean;
   }
 
-  interface GuiSettingsModal {
+  export interface GuiSettingsModal {
     layout: GuiSettingsLayout;
     position?: GuiSettingsPosition;
     transition?: Transition;
   }
 
-  interface GuiOptions {
+  export interface GuiOptions {
     consent_modal?: GuiConsentModal;
     settings_modal?: GuiSettingsModal;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,5 @@
-import { CookieConsentCategoryValues, Values } from './types';
+import { CookieConsentCategoryValues, Values, VanillaCookieConsent } from './types';
 import { CookieConsentCategory, SecondaryButtonMode } from './constants';
-import { VanillaCookieConsent } from './types/vanilla-cookieconsent';
 
 export const addSeparators = (strings: string[], and: string = ''): string =>
   strings.reduce((accumulator: string, string: string, i: number) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
-import { Values } from './types';
-import { SecondaryButtonMode } from './constants';
+import { CookieConsentCategoryValues, Values } from './types';
+import { CookieConsentCategory, SecondaryButtonMode } from './constants';
 import { VanillaCookieConsent } from './types/vanilla-cookieconsent';
 
 export const addSeparators = (strings: string[], and: string = ''): string =>
@@ -51,4 +51,40 @@ export const assembleSecondaryButton = (
 
 export const isSettingsButtonNotShown = (secondaryButtonMode: Values<typeof SecondaryButtonMode>): boolean => {
   return secondaryButtonMode !== SecondaryButtonMode.SHOW_SETTINGS;
+};
+
+export const assembleCategoryNecessary = (title: string, description: string): VanillaCookieConsent.ModalBlock => {
+  return assembleCategoryBlock(CookieConsentCategory.NECESSARY, title, description, true);
+};
+
+export const assembleCategoryAd = (title: string, description: string): VanillaCookieConsent.ModalBlock => {
+  return assembleCategoryBlock(CookieConsentCategory.AD, title, description, false);
+};
+
+export const assembleCategoryAnalytics = (title: string, description: string): VanillaCookieConsent.ModalBlock => {
+  return assembleCategoryBlock(CookieConsentCategory.ANALYTICS, title, description, false);
+};
+
+export const assembleCategoryFunctionality = (title: string, description: string): VanillaCookieConsent.ModalBlock => {
+  return assembleCategoryBlock(CookieConsentCategory.FUNCTIONALITY, title, description, false);
+};
+
+export const assembleCategoryPersonalization = (
+  title: string,
+  description: string,
+): VanillaCookieConsent.ModalBlock => {
+  return assembleCategoryBlock(CookieConsentCategory.PERSONALIZATION, title, description, false);
+};
+
+const assembleCategoryBlock = (
+  category: CookieConsentCategoryValues,
+  title: string,
+  description: string,
+  readonly: boolean,
+): VanillaCookieConsent.ModalBlock => {
+  return {
+    title,
+    description,
+    toggle: { value: category, enabled: readonly, readonly },
+  };
 };


### PR DESCRIPTION
As discussed in #324, I made at least some DRY simplification of block assembly, so that the language files contains less logic. 

This PR will go before #324 , ie. #324 will be refactored to extend and utilize the `assembleCategoryBlock` method.

What do you think, @literat?