### PR TITLE
Feat: Use deep merge for config overwrites (fixes #385)

### DIFF
--- a/examples/configuration.html
+++ b/examples/configuration.html
@@ -161,11 +161,9 @@
         consentCollectorApiUrl: 'https://ccm.lmc.cz/local-data-acceptation-data-entries?Spot=(public,demo)', // override default URL for demo purposes; do not set custom consentCollectorApiUrl unless you have been explicitly guided to do so!
         config: { // override default config of the underlying library, see https://cookieconsent.orestbida.com/reference/configuration-reference.html
           manageScriptTags: false, // disable management of <script> attributes, see https://github.com/lmc-eu/cookie-consent-manager#third-party-scripts-loaded-via-script
-          // TODO: this will work properly once the values are merged instead of overridden on the first level
-          // https://github.com/lmc-eu/cookie-consent-manager/issues/385
-          // cookie: {
-          //     expiresAfterDays: 30, // expire consent after 30 days instead of default 60 (when only necessary accepted)
-          // },
+          cookie: {
+              expiresAfterDays: 30, // expire consent after 30 days instead of default 60 (when only necessary accepted)
+          },
         },
         onAccept: () => document.getElementById('reset').removeAttribute('hidden'), // reveal Reset cookie button
         onFirstAccept: ({ cookieConsent }) => { // user just clicked and gave consent to selected or all categories

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@lmc-eu/spirit-design-tokens": "^1.1.3",
     "mergician": "^2.0.2",
-    "nanoid": "5.0.9",
+    "nanoid": "^5.0.9",
     "vanilla-cookieconsent": "3.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   },
   "dependencies": {
     "@lmc-eu/spirit-design-tokens": "^1.1.3",
+    "mergician": "^2.0.2",
     "nanoid": "5.0.9",
     "vanilla-cookieconsent": "3.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6081,15 +6081,15 @@ muggle-string@^0.4.1:
   resolved "https://registry.yarnpkg.com/muggle-string/-/muggle-string-0.4.1.tgz#3b366bd43b32f809dc20659534dd30e7c8a0d328"
   integrity sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==
 
-nanoid@5.0.9:
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.0.9.tgz#977dcbaac055430ce7b1e19cf0130cea91a20e50"
-  integrity sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==
-
 nanoid@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
+
+nanoid@^5.0.9:
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.0.9.tgz#977dcbaac055430ce7b1e19cf0130cea91a20e50"
+  integrity sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==
 
 natural-compare@^1.4.0:
   version "1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5965,6 +5965,11 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
+mergician@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mergician/-/mergician-2.0.2.tgz#353270cadb3c770854399cf47b04aff38e5a9faf"
+  integrity sha512-1GDF4LuMcc7UpE7XitfSm822yDtTxLoOVB+9QFnb3o/+zoMAVKxM67UjvmEXOA7FQnz9209K0ZyHAoD+5Ibe4A==
+
 micromatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"


### PR DESCRIPTION
This allows to overwrite multi-level deep config object of the vanilla-cookieconsent.

Used library [Mergican](https://github.com/jhildenbiddle/mergician) is light-weight and does not extend the dependency footprint, as it has no external dependencies.