### PR TITLE
BREAKING CHANGE: Rename callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ To execute custom code which depends on cookie consent use callbacks:
 initLmcCookieConsentManager(
   'demo.example',
   {
-    onAccept: (cookieConsent) => {
+    onConsent: (cookieConsent) => {
       if (cookieConsent.allowedCategory('functionality')) {
         startOptionalFeature();
       }
@@ -226,7 +226,7 @@ initLmcCookieConsentManager( // when loaded as a module, these options are passe
   {
     defaultLang: 'cs',
     autodetectLang: false,
-    onAccept: (cookieConsent) => {
+    onConsent: (cookieConsent) => {
       // custom code
     },
     translationOverrides: { // overrides of the default translation for specified languages
@@ -308,8 +308,8 @@ which can be used to call [its methods][cookie consent api] or retrieve data fro
 
 | Callback                              | Trigger event                                                                                                                                                       |
 |---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `onFirstAccept(cookieConsent)`        | This function will be executed only once, when the user takes the first action (accept all/only selected/only necessary categories).                                |
-| `onAccept(cookieConsent)`             | Any consent is detected (either given now or after page load if it was already saved previously)                                                                    |
+| `onFirstConsent(cookieConsent)`       | This function will be executed only once, when the user takes the first action (accept all/only selected/only necessary categories).                                |
+| `onConsent(cookieConsent)`            | Any consent is detected (either given now or after page load if it was already saved previously)                                                                    |
 | `onChange(cookieConsent, categories)` | Right after the user changes cookie settings. The callback receives also `categories` object containing arrays of `accepted`, `rejected`, and `changed` categories. |
 
 [👀 See callbacks example][examples-callbacks]

--- a/examples/callbacks.html
+++ b/examples/callbacks.html
@@ -112,8 +112,8 @@
 
                 <h2 class="mt-md-3 mb-3">Callbacks</h2>
                 <ul class="list-group list-callbacks">
-                    <li class="list-group-item" id="callback-onFirstAccept">onFirstAccept</li>
-                    <li class="list-group-item" id="callback-onAccept">onAccept</li>
+                    <li class="list-group-item" id="callback-onFirstConsent">onFirstConsent</li>
+                    <li class="list-group-item" id="callback-onConsent">onConsent</li>
                     <li class="list-group-item" id="callback-onChange">onChange</li>
                 </ul>
 
@@ -152,13 +152,13 @@
       {
         consentCollectorApiUrl: 'https://ccm.lmc.cz/local-data-acceptation-data-entries?Spot=(public,demo)', // override default URL for demo purposes; do not set custom consentCollectorApiUrl unless you have been explicitly guided to do so!
         displayMode: 'soft', // show consent in a bottom banner and do not force user action before page could be used
-        onAccept: ({cookieConsent}) => { // any type of consent detected (including only necessary, custom selection or all categories)
-          markCallbackCalled('onAccept');
+        onConsent: ({cookieConsent}) => { // any type of consent detected (including only necessary, custom selection or all categories)
+          markCallbackCalled('onConsent');
           updateAcceptedCategories(cookieConsent);
           document.getElementById('reset').removeAttribute('hidden'); // reveal Reset cookie button
         },
-        onFirstAccept: ({cookieConsent}) => { // user just clicked and gave consent to selected or all categories
-          markCallbackCalled('onFirstAccept');
+        onFirstConsent: ({cookieConsent}) => { // user just clicked and gave consent to selected or all categories
+          markCallbackCalled('onFirstConsent');
 
           if (cookieConsent.acceptedCategory('functionality')) { // check for specific consent category
             console.log('Consent for extended functionality given');

--- a/examples/configuration.html
+++ b/examples/configuration.html
@@ -109,7 +109,7 @@
                         Overwriting raw configuration of the underlying cookie-consent component (via <code>config</code> option),
                         to modify some advanced features.
                     </li>
-                    <li>Clearing localStorage when user gives consent to only necessary data (<code>onFirstAccept</code>)</li>
+                    <li>Clearing localStorage when user gives consent to only necessary data (<code>onFirstConsent</code>)</li>
                     <li>Clearing localStorage when user updates consent and rejects some consent category (<code>onChange</code>)</li>
                     <li>Using <code>cookieTable</code> configuration to list cookies in the settings modal</li>
                     <li>Overriding default translation (<code>translationOverrides</code>) for consent modal title</li>
@@ -165,8 +165,8 @@
               expiresAfterDays: 30, // expire consent after 30 days instead of default 60 (when only necessary accepted)
           },
         },
-        onAccept: () => document.getElementById('reset').removeAttribute('hidden'), // reveal Reset cookie button
-        onFirstAccept: ({ cookieConsent }) => { // user just clicked and gave consent to selected or all categories
+        onConsent: () => document.getElementById('reset').removeAttribute('hidden'), // reveal Reset cookie button
+        onFirstConsent: ({ cookieConsent }) => { // user just clicked and gave consent to selected or all categories
             if (!cookieConsent.acceptedCategory('functionality')) {
               window.localStorage.clear(); // if we use localStorage only for some extended "functionality", remove its contents if we don't have consent
             }

--- a/examples/index.html
+++ b/examples/index.html
@@ -119,8 +119,8 @@
                     <li class="list-group-item" id="consent-personalization">personalization</li>
                 </ul>
 
-                <h2 class="mt-4 mt-md-5 mb-3">Content set from <code>onFirstAccept()</code> callback</h2>
-                <p id="onFirstAccept-content">
+                <h2 class="mt-4 mt-md-5 mb-3">Content set from <code>onFirstConsent()</code> callback</h2>
+                <p id="onFirstConsent-content">
                     (empty)
                 </p>
 
@@ -164,15 +164,15 @@
       {
         consentCollectorApiUrl: 'https://ccm.lmc.cz/local-data-acceptation-data-entries?Spot=(public,demo)', // override default URL for demo purposes; do not set custom consentCollectorApiUrl unless you have been explicitly guided to do so!
         displayMode: 'soft', // show consent in a bottom banner and do not force user action before page could be used
-        onAccept: ({ cookieConsent }) => { // any type of consent detected (including only necessary, custom selection or all categories)
+        onConsent: ({ cookieConsent }) => { // any type of consent detected (including only necessary, custom selection or all categories)
           if (cookieConsent.acceptedCategory('ad')) {
             document.getElementById('ad-content').innerHTML = 'Ad consent allowed';
           }
           updateAcceptedCategories(cookieConsent);
           document.getElementById('reset').removeAttribute('hidden'); // reveal Reset cookie button
         },
-        onFirstAccept: () => {  // user just clicked and gave consent to selected or all categories
-          document.getElementById('onFirstAccept-content').innerHTML = '<code>onFirstAccept()</code> called';
+        onFirstConsent: () => {  // user just clicked and gave consent to selected or all categories
+          document.getElementById('onFirstConsent-content').innerHTML = '<code>onFirstConsent()</code> called';
         },
         onChange: ({ cookieConsent, categories }) => { // user previously gave consent but now change its preferences
           if (categories.changed.includes('ad')) {

--- a/examples/languages.html
+++ b/examples/languages.html
@@ -184,7 +184,7 @@
           displayMode: 'soft', // show consent in a bottom banner and do not force user action before page could be used
           companyNames: ['Alma Career', 'Some Other Company', 'ACME'],
           consentCollectorApiUrl: 'https://ccm.lmc.cz/local-data-acceptation-data-entries?Spot=(public,demo)',
-          onAccept: () => document.getElementById('reset').removeAttribute('hidden'), // reveal Reset cookie button
+          onConsent: () => document.getElementById('reset').removeAttribute('hidden'), // reveal Reset cookie button
         }
     );
   });

--- a/examples/theming.html
+++ b/examples/theming.html
@@ -248,7 +248,7 @@
       {
         consentCollectorApiUrl: 'https://ccm.lmc.cz/local-data-acceptation-data-entries?Spot=(public,demo)', // override default URL for demo purposes; do not set custom consentCollectorApiUrl unless you have been explicitly guided to do so!
         displayMode: 'soft', // show consent in a bottom banner and do not force user action before page could be used
-        onAccept: () => document.getElementById('reset').removeAttribute('hidden'), // reveal Reset cookie button
+        onConsent: () => document.getElementById('reset').removeAttribute('hidden'), // reveal Reset cookie button
       }
     );
   });

--- a/src/LmcCookieConsentManager.ts
+++ b/src/LmcCookieConsentManager.ts
@@ -6,7 +6,7 @@ import {
   CategoriesChangeset,
   CookieConsentManager,
   CookieConsentManagerOptions,
-  OnAcceptCallback,
+  OnConsentCallback,
   OnChangeCallback,
 } from './types';
 import { CookieConsentCategory, DisplayMode } from './constants';
@@ -16,7 +16,7 @@ import * as CookieConsent from 'vanilla-cookieconsent';
 import { AcceptType, CookieConsentConfig, CookieValue } from 'vanilla-cookieconsent';
 
 /* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-empty-function */
-const noopAcceptCallback: OnAcceptCallback = () => {};
+const noopConsentCallback: OnConsentCallback = () => {};
 /* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-empty-function */
 const noopChangeCallback: OnChangeCallback = () => {};
 
@@ -24,8 +24,8 @@ const defaultOptions: CookieConsentManagerOptions = {
   defaultLang: 'cs',
   autodetectLang: true,
   consentCollectorApiUrl: 'https://ccm.lmc.cz/local-data-acceptation-data-entries',
-  onFirstAccept: noopAcceptCallback,
-  onAccept: noopAcceptCallback,
+  onFirstConsent: noopConsentCallback,
+  onConsent: noopConsentCallback,
   onChange: noopChangeCallback,
   companyNames: ['Alma Career'],
   displayMode: DisplayMode.FORCE,
@@ -41,9 +41,9 @@ const defaultOptions: CookieConsentManagerOptions = {
  * @param {boolean} [args.autodetectLang] - Autodetect language from the browser
  * @param {?string} [args.consentCollectorApiUrl] - URL of the API where user consent information should be sent.
  *   Null to disable.
- * @param {OnFirstAcceptCallback} [args.onFirstAccept] - Callback to be executed right after any consent is just accepted
- * @param {OnAcceptCallback} [args.onAccept] - Callback to be executed when any consent is detected (either given right now
- *   or already saved previously)
+ * @param {OnFirstConsentCallback} [args.onFirstConsent] - Callback to be executed right after any consent is just accepted
+ * @param {OnConsentCallback} [args.onConsent] - Callback to be executed when any consent is detected (either given
+ *   right now or already saved previously)
  * @param {OnChangeCallback} [args.onChange] - Callback to be executed right after user change his/her preferences
  * @param {Array} [args.companyNames] - Array of strings with company names. Adjust only when the consent needs
  *   to be given to multiple companies.
@@ -66,8 +66,8 @@ const LmcCookieConsentManager: CookieConsentManager = (serviceName, args) => {
     defaultLang,
     autodetectLang,
     consentCollectorApiUrl,
-    onFirstAccept,
-    onAccept,
+    onFirstConsent,
+    onConsent,
     onChange,
     companyNames,
     displayMode,
@@ -78,8 +78,7 @@ const LmcCookieConsentManager: CookieConsentManager = (serviceName, args) => {
   const cookieName = 'almacareer_ccm';
   const cookieConsent = CookieConsent;
 
-  // TODO: rename to onFirstConsentHandler?
-  const onFirstAcceptHandler = ({ cookie }: { cookie: CookieValue }) => {
+  const onFirstConsentHandler = ({ cookie }: { cookie: CookieValue }) => {
     const cookieData = cookieConsent.getCookie('data');
     if (cookieData == null || !('uid' in cookieData)) {
       cookieConsent.setCookieData({
@@ -94,11 +93,11 @@ const LmcCookieConsentManager: CookieConsentManager = (serviceName, args) => {
       submitConsent(consentCollectorApiUrl, cookieConsent.getCookie(), cookieConsent.getUserPreferences());
     }
 
-    onFirstAccept({ cookieConsent, cookie: cookieConsent.getCookie() });
+    onFirstConsent({ cookieConsent, cookie: cookieConsent.getCookie() });
   };
 
-  const onAcceptHandler = ({ cookie }: { cookie: CookieValue }) => {
-    onAccept({ cookieConsent, cookie });
+  const onConsentHandler = ({ cookie }: { cookie: CookieValue }) => {
+    onConsent({ cookieConsent, cookie });
   };
 
   const onChangeHandler = ({
@@ -155,8 +154,8 @@ const LmcCookieConsentManager: CookieConsentManager = (serviceName, args) => {
           equalWeightButtons: false,
         },
       },
-      onConsent: onAcceptHandler,
-      onFirstConsent: onFirstAcceptHandler,
+      onConsent: onConsentHandler,
+      onFirstConsent: onFirstConsentHandler,
       onChange: onChangeHandler,
       categories: {
         necessary: {

--- a/src/types/CookieConsentManager.ts
+++ b/src/types/CookieConsentManager.ts
@@ -12,8 +12,8 @@ export type CategoriesChangeset = {
   changed: CookieConsentCategoryValues[];
 };
 
-export type OnFirstAcceptCallback = (param: { cookieConsent: typeof CookieConsent; cookie: CookieValue }) => void;
-export type OnAcceptCallback = (param: { cookieConsent: typeof CookieConsent; cookie: CookieValue }) => void;
+export type OnFirstConsentCallback = (param: { cookieConsent: typeof CookieConsent; cookie: CookieValue }) => void;
+export type OnConsentCallback = (param: { cookieConsent: typeof CookieConsent; cookie: CookieValue }) => void;
 export type OnChangeCallback = (param: {
   cookieConsent: typeof CookieConsent;
   cookie: CookieValue;
@@ -38,8 +38,8 @@ export type CookieConsentManagerOptions = {
   defaultLang: string;
   autodetectLang: boolean;
   consentCollectorApiUrl: string;
-  onFirstAccept: OnFirstAcceptCallback;
-  onAccept: OnAcceptCallback;
+  onFirstConsent: OnFirstConsentCallback;
+  onConsent: OnConsentCallback;
   onChange: OnChangeCallback;
   companyNames: string[];
   displayMode: Values<typeof DisplayMode>;


### PR DESCRIPTION
To match their new names in vanilla-cookieconsent library.

This causes BC, however, I find this better than having different names from the vanilla library. 